### PR TITLE
docs: expand zensical site coverage

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -8,6 +8,12 @@ All plugin settings are configured in `PLUGINS_CONFIG` within your NetBox `confi
 |---------|-------|-------------|
 | `srid`  | `int` | Spatial reference system ID for stored geometries (e.g. `3348` for NAD83(CSRS)) |
 
+!!! danger "SRID is immutable"
+    The `srid` value is baked into PostGIS columns at migration time and
+    cannot be changed after data has been loaded without manual
+    re-projection. See [SRID Selection](srid.md) for guidance on which EPSG
+    code to choose and how to recover from a mistake.
+
 ## Map Settings
 
 ```python
@@ -28,8 +34,8 @@ PLUGINS_CONFIG = {
 | `map_zoom`           | `int`   | `10`                            | Default zoom level (1-22)                |
 | `map_tiles`          | `str`   | OpenStreetMap URL               | Tile URL template (fallback, see below)  |
 | `map_max_native_zoom`| `int`   | `19`                            | Max native zoom for fallback tiles       |
-| `map_attribution`    | `str`   | `© OpenStreetMap contributors`  | Attribution for fallback tiles           |
-| `map_base_layers`    | `list`  | —                               | Custom base layer definitions (see below)|
+| `map_attribution`    | `str`   | `(c) OpenStreetMap contributors`| Attribution for fallback tiles           |
+| `map_base_layers`    | `list`  | --                               | Custom base layer definitions (see below)|
 | `map_overlays`       | `list`  | `[]`                            | WMS/WMTS/tile overlay layers             |
 
 ## Tile Providers
@@ -76,7 +82,7 @@ PLUGINS_CONFIG = {
 
 Available Mapbox styles include `light-v11`, `dark-v11`, `streets-v12`, `outdoors-v12`, `satellite-v9`, `satellite-streets-v12`, `navigation-day-v1`, and `navigation-night-v1`. See [Mapbox Styles documentation](https://docs.mapbox.com/api/maps/styles/) for the full list.
 
-The tile URLs use the Mapbox Styles API (`/styles/v1/`), which renders vector styles as raster tiles — required for Leaflet compatibility. Set `tileSize: 512` and `zoomOffset: -1` for Mapbox 512px tiles.
+The tile URLs use the Mapbox Styles API (`/styles/v1/`), which renders vector styles as raster tiles -- required for Leaflet compatibility. Set `tileSize: 512` and `zoomOffset: -1` for Mapbox 512px tiles.
 
 ### OpenStreetMap (default)
 
@@ -99,8 +105,8 @@ Note that OSM tiles are limited to zoom level 19, while Mapbox supports up to 22
 
 The plugin automatically registers these Django apps via `PluginConfig.django_apps`:
 
-- `django.contrib.gis` — Geographic model fields and spatial queries
-- `rest_framework_gis` — GeoJSON serializer support for the REST API
+- `django.contrib.gis` -- Geographic model fields and spatial queries
+- `rest_framework_gis` -- GeoJSON serializer support for the REST API
 
 You do not need to add these to `INSTALLED_APPS` manually.
 

--- a/docs/getting-started/postgis-setup.md
+++ b/docs/getting-started/postgis-setup.md
@@ -1,0 +1,140 @@
+# PostGIS Setup
+
+NetBox Pathways requires PostGIS. NetBox itself runs against plain PostgreSQL
+out of the box, so adding this plugin means changing your database
+configuration. This page covers what to install, how to enable the extension,
+and how to configure NetBox to use the PostGIS database backend.
+
+## Required Versions
+
+| Component        | Minimum |
+|------------------|---------|
+| PostgreSQL       | 16      |
+| PostGIS          | 3.4     |
+| GDAL             | 3.x     |
+| GEOS             | 3.10    |
+| PROJ             | 8       |
+
+GDAL, GEOS, and PROJ are C libraries used by Django's GIS layer. They must be
+installed on the host running the NetBox web workers, not just on the database
+server.
+
+## Installing System Libraries
+
+=== "Debian / Ubuntu"
+
+    ```bash
+    sudo apt-get update
+    sudo apt-get install -y \
+        gdal-bin libgdal-dev \
+        libgeos-dev \
+        libproj-dev \
+        binutils
+    ```
+
+=== "RHEL / Rocky / AlmaLinux"
+
+    ```bash
+    sudo dnf install -y epel-release
+    sudo dnf install -y \
+        gdal gdal-devel \
+        geos geos-devel \
+        proj proj-devel
+    ```
+
+=== "Alpine (Docker)"
+
+    ```dockerfile
+    RUN apk add --no-cache \
+        gdal gdal-dev \
+        geos geos-dev \
+        proj proj-dev \
+        binutils
+    ```
+
+## Enabling the PostGIS Extension
+
+Connect to the NetBox database as a superuser and run:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS postgis;
+```
+
+Verify it was installed:
+
+```sql
+SELECT PostGIS_Version();
+```
+
+You should see something like `3.4 USE_GEOS=1 USE_PROJ=1 USE_STATS=1`.
+
+## Database Backend Configuration
+
+In `configuration.py`, change the `DATABASE` engine from the default
+PostgreSQL backend to the PostGIS one:
+
+```python
+DATABASE = {
+    "ENGINE": "django.contrib.gis.db.backends.postgis",
+    "NAME": "netbox",
+    "USER": "netbox",
+    "PASSWORD": "...",
+    "HOST": "localhost",
+    "PORT": "",
+    "CONN_MAX_AGE": 300,
+}
+```
+
+!!! warning
+    The plain `django.db.backends.postgresql` backend will appear to work
+    until the first migration that creates a geometry column, which then
+    fails because the backend has no idea what `geometry()` is. Always set
+    the PostGIS backend before running `migrate netbox_pathways`.
+
+## Migrating an Existing NetBox Database
+
+If you have an established NetBox install on plain PostgreSQL and are adding
+this plugin to it:
+
+1. Take a backup. `pg_dump` the entire NetBox database.
+2. Install PostGIS system packages on the database server, restart Postgres.
+3. Run `CREATE EXTENSION postgis;` on the existing database. No data
+   migration is required for existing core tables; PostGIS lives alongside
+   plain PostgreSQL features.
+4. Switch `DATABASE['ENGINE']` to the PostGIS backend.
+5. Choose your SRID. See [SRID Selection](srid.md). This decision is
+   permanent.
+6. Run `python manage.py migrate netbox_pathways`.
+7. Restart `netbox` and `netbox-rq` services.
+
+## Containerised Setup (DevContainer / Docker Compose)
+
+The plugin's bundled DevContainer uses `postgis/postgis:16-3.4` as the
+database image. If you are building your own Compose stack, use that image
+or another `postgis` tag pinned to the version above.
+
+```yaml
+services:
+  postgres:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_DB: netbox
+      POSTGRES_USER: netbox
+      POSTGRES_PASSWORD: netbox
+```
+
+The official NetBox Docker image already bundles GDAL, so no additional
+build steps are needed on the application side.
+
+## Verifying The Stack
+
+After installing the plugin, run the Django system check:
+
+```bash
+python manage.py check netbox_pathways
+```
+
+It should report no issues. Then create a test structure through the UI or
+the API. If geometry input fails with errors mentioning `postgis`, `gdal`,
+or `geos`, one of the system libraries is missing or the database backend is
+still set to plain PostgreSQL.

--- a/docs/getting-started/srid.md
+++ b/docs/getting-started/srid.md
@@ -1,0 +1,139 @@
+# SRID Selection
+
+The `srid` setting in `PLUGINS_CONFIG['netbox_pathways']` is the single most important
+decision you make before installing this plugin. It determines the spatial reference
+system used for every geometry column the plugin creates in your database.
+
+!!! danger "The SRID is immutable after first migration"
+    The `srid` value is baked into PostGIS geometry columns at migration time.
+    Changing the setting after data has been loaded **will not** re-project the
+    stored coordinates. Geometries will retain their original numeric values but
+    PostGIS will interpret them as belonging to the new CRS, which corrupts every
+    spatial query and every map render. There is no automatic recovery.
+
+    Choose your SRID carefully. Test the plugin on an empty database first if you
+    are unsure.
+
+## What an SRID Is
+
+An SRID (Spatial Reference Identifier) is a numeric handle for a coordinate
+reference system. Most production deployments use an
+[EPSG](https://epsg.io/) code, for example `4326` for WGS84 latitude/longitude
+or `3857` for Web Mercator. The plugin stores every `Point`, `LineString`, and
+`Polygon` field with the SRID you configure.
+
+Storage SRID is independent of how data is exchanged with the map and the
+GeoJSON API. Both always use EPSG:4326 (WGS84). The plugin transforms in and
+out of your storage SRID automatically using PostGIS `ST_Transform`.
+
+## How To Choose
+
+The right SRID depends on the geographic extent of your network and the kinds
+of measurements you want PostGIS to make accurately.
+
+### Small geographic footprint, accurate distances
+
+If all your infrastructure fits inside one country or one UTM zone, pick a
+projected CRS measured in meters. Length, area, and buffer queries will return
+real-world meters without further math. Examples:
+
+| EPSG    | CRS                                              | Best for                       |
+|---------|--------------------------------------------------|--------------------------------|
+| `3348`  | NAD83(CSRS) / Statistics Canada Lambert          | All of Canada                  |
+| `2154`  | RGF93 / Lambert-93                               | Mainland France                |
+| `25832` | ETRS89 / UTM zone 32N                            | Central Europe (e.g. Germany)  |
+| `32188` | NAD83 / MTM zone 8                               | Quebec, Canada                 |
+| `27700` | OSGB 1936 / British National Grid                | Great Britain                  |
+| `3577`  | GDA94 / Australian Albers                        | Australia                      |
+| `2272`  | NAD83 / Pennsylvania South (US ft)               | Pennsylvania, USA              |
+
+### Global or mixed extent
+
+If your network spans multiple continents, a single projected CRS will distort
+distances at the edges. WGS84 stores raw degrees and is universally supported.
+Web Mercator stores meters projected for tile maps but distorts area near the
+poles.
+
+| EPSG   | CRS                              | Notes                                        |
+|--------|----------------------------------|----------------------------------------------|
+| `4326` | WGS84 (degrees lat/lon)          | Global. Distance queries return degrees.     |
+| `3857` | WGS 84 / Pseudo-Mercator         | What slippy-map tiles use. Meters but warped near poles. |
+
+### Inside-plant only
+
+If every structure and pathway is inside a single building, you can still use
+WGS84 (degrees). You will not benefit from a projected CRS at building scale,
+and using one designed for a wider area introduces complexity without payoff.
+
+## Setting the SRID
+
+In your NetBox `configuration.py`:
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_pathways": {
+        "srid": 3348,
+    },
+}
+```
+
+The setting is `required_settings` on `PluginConfig`. Starting NetBox without
+it will raise `ImproperlyConfigured` from `netbox_pathways.geo.get_srid()` on
+first request.
+
+## Verifying the Configured SRID
+
+After running migrations, confirm the column SRID matches your setting:
+
+```sql
+SELECT f_table_name, f_geometry_column, srid
+FROM geometry_columns
+WHERE f_table_schema = 'public'
+  AND f_table_name LIKE 'netbox_pathways_%';
+```
+
+Every row should report the SRID you set. If any row reports a different
+value, your configuration was changed after migration and your geometry data
+is now misaligned.
+
+## Recovering From a Wrong SRID
+
+There is no safe one-line fix. If you discover the SRID is wrong after data
+has been loaded, you must:
+
+1. Take a database backup before doing anything else.
+2. Determine which CRS the existing coordinates were actually authored in
+   (the old setting), call this `OLD_SRID`. Determine the desired storage SRID,
+   call this `NEW_SRID`.
+3. For every geometry column, run a PostGIS update that reinterprets the data
+   in `OLD_SRID` and re-projects it to `NEW_SRID`:
+
+    ```sql
+    -- Example for the structures table
+    UPDATE netbox_pathways_structure
+    SET location = ST_Transform(ST_SetSRID(location, OLD_SRID), NEW_SRID);
+
+    -- Update the column constraint
+    SELECT UpdateGeometrySRID(
+      'netbox_pathways_structure',
+      'location',
+      NEW_SRID
+    );
+    ```
+
+4. Repeat for every geometry column on every pathways model
+   (`structure.location`, `pathway.path`, `sitegeometry.geometry`,
+   `circuitgeometry.path`).
+5. Update `PLUGINS_CONFIG['netbox_pathways']['srid']` to `NEW_SRID` and restart
+   NetBox.
+
+This is a database-administrator operation. Do it on a copy of production data
+before touching production.
+
+## Why The Plugin Hard-Codes Storage SRID
+
+Mixing per-row SRIDs in a column is legal in PostGIS but forces every spatial
+query to specify the right SRID at call time, breaks spatial indexes, and
+makes development much more error prone. The plugin uses one SRID throughout
+the database and transforms only at the API boundary, where performance is
+amortised over per-row serialisation work.

--- a/docs/user-guide/circuit-geometry.md
+++ b/docs/user-guide/circuit-geometry.md
@@ -1,0 +1,64 @@
+# Circuit Geometry
+
+A **Circuit Geometry** records a provider-described route for a NetBox
+`circuits.Circuit`. The circuit itself remains a black box managed by
+NetBox core; this model adds a LineString that says "the provider tells us
+the circuit follows this physical path", suitable for display on the
+infrastructure map.
+
+## Why It Is Separate
+
+NetBox's Circuits app describes services in business terms (provider,
+type, status, terminations). It deliberately does not model the physical
+path the carrier uses. Many operators still want to overlay carrier-
+described routes on their plant map for awareness; that is what this
+model is for.
+
+The geometry is informational. It is not used for cable tracing, route
+planning, or any pathway logic. Storing a route here does not create
+`CableSegment` records or affect any other Pathways model.
+
+## Fields
+
+| Field                | Type            | Notes                                                                |
+|----------------------|-----------------|----------------------------------------------------------------------|
+| `circuit`            | OneToOne Circuit| The NetBox circuit this geometry belongs to.                         |
+| `path`               | LineString      | The route, in your configured SRID. Always a LineString, never null. |
+| `provider_reference` | string          | Provider's route ID, span ID, or document reference. Optional.       |
+| `comments`           | text            | Free-form notes.                                                     |
+
+## Display
+
+The plugin exposes circuit geometries via the GeoJSON API at
+`/api/plugins/pathways/geo/circuits/`. The serialised properties are:
+
+| Property             | Source                          |
+|----------------------|---------------------------------|
+| `id`                 | `CircuitGeometry.id`            |
+| `cid`                | `circuit.cid`                   |
+| `provider`           | `circuit.provider.name`         |
+| `circuit_type`       | `circuit.type.name`             |
+| `status`             | `circuit.status`                |
+| `provider_reference` | `CircuitGeometry.provider_reference` |
+
+You can register this endpoint as a layer in QGIS, or rely on the
+plugin's interactive map (where it can be enabled as a layer through
+the layer toggle controls, when present).
+
+## Workflow
+
+1. Create the `circuits.Circuit` in NetBox core as usual (provider,
+   type, terminations).
+2. Navigate to **Plugins > Pathways > Circuit Geometries**.
+3. Click **Add**, select the circuit, and draw the route on the map.
+4. Optionally fill in `provider_reference` (for example, the provider's
+   span/route ID printed on their fibre map) and `comments`.
+5. Save.
+
+## Updating Routes
+
+Routes change when carriers re-engineer their network. Simply edit the
+existing `CircuitGeometry` to update the path. Because the model is a
+OneToOne to `Circuit`, there is at most one geometry per circuit; if you
+need to record route history, use a custom field or comments rather than
+multiple records.

--- a/docs/user-guide/conduit-banks.md
+++ b/docs/user-guide/conduit-banks.md
@@ -1,0 +1,102 @@
+# Conduit Banks
+
+A **Conduit Bank** is an encased group of conduits that share a single
+physical route between two structures. On the map the bank is what gets
+drawn; the conduits inside it are detail records visible only on the bank's
+detail page and in the cable routing UI.
+
+This page focuses on banks specifically. For routing cables through banks
+and individual conduits, see [Cable Routing](cable-routing.md).
+
+## When To Model A Bank Versus Standalone Conduits
+
+| Use a bank when                                                    | Use standalone conduits when                       |
+|--------------------------------------------------------------------|----------------------------------------------------|
+| Multiple conduits share an excavation, encasement, or duct rack.   | A single conduit runs between two structures.      |
+| You need to record a configuration like 2x2 or 3x3.                | The conduit is in a different trench than its peers.|
+| You want the map to show one feature, not N parallel lines.        | You need to draw distinct paths per conduit.       |
+
+A conduit may belong to at most one bank. Removing the `conduit_bank`
+foreign key promotes that conduit back to a map-visible feature.
+
+## Bank Fields
+
+| Field             | Type        | Notes                                                            |
+|-------------------|-------------|------------------------------------------------------------------|
+| `label`           | string      | Inherited from `Pathway`. Optional but strongly recommended.     |
+| `path`            | LineString  | The geographic route of the bank. Drawn on the map widget.       |
+| `start_structure` | FK          | First end of the bank. Required at one of structure or location. |
+| `end_structure`   | FK          | Second end of the bank.                                          |
+| `start_face`      | choice      | Which face of the start structure (north/south/east/west/other). |
+| `end_face`        | choice      | Which face of the end structure.                                 |
+| `configuration`   | choice      | Layout shape, see table below. Leave blank if irregular.         |
+| `total_conduits`  | int         | Designed capacity in slots. May be more than the actual count.   |
+| `encasement_type` | choice      | Concrete, direct buried, bore, bridge attachment, tunnel.        |
+
+The bank inherits the rest of `Pathway` (tenant, length, installation date,
+comments).
+
+### Configuration Choices
+
+| Value    | Layout              | Total conduits |
+|----------|---------------------|----------------|
+| `1x2`    | 1 row x 2 columns    | 2              |
+| `1x3`    | 1 row x 3 columns    | 3              |
+| `1x4`    | 1 row x 4 columns    | 4              |
+| `2x2`    | 2 rows x 2 columns   | 4              |
+| `2x3`    | 2 rows x 3 columns   | 6              |
+| `3x3`    | 3 rows x 3 columns   | 9              |
+| `3x4`    | 3 rows x 4 columns   | 12             |
+| `custom` | Irregular layout     | Variable       |
+
+`total_conduits` is a separate field because real installations often
+provide spare capacity beyond what the named configuration implies, or use
+non-grid layouts described as `custom`.
+
+### Encasement Types
+
+| Value               | Description                                  |
+|---------------------|----------------------------------------------|
+| `concrete`          | Concrete-encased duct bank.                  |
+| `direct_buried`     | Buried without concrete jacket.              |
+| `bore`              | Pulled through a directional bore.           |
+| `bridge_attachment` | Attached to bridge or other span structure.  |
+| `tunnel`            | Inside a tunnel or shared utility corridor.  |
+
+## Bank Position On Conduits
+
+Conduits inside a bank carry a `bank_position` like `A1` or `B3`:
+
+- Row letter (`A`, `B`, ...) names the row, with `A` as the top.
+- Column number (`1`, `2`, ...) names the column, with `1` on the left.
+- The combination of `(conduit_bank, bank_position)` is unique. The
+  database enforces this with a partial unique constraint when both fields
+  are populated.
+
+Position is a free-text field, so you can use any naming you like
+(`L-1`, `R-2`, `slot-3a`). Stay consistent inside one organisation.
+
+## Map Behaviour
+
+A bank renders as a single LineString on the interactive map and on
+exported QGIS layers. The conduits inside it do not appear as separate
+features (`Conduit.map_visible` returns `False` when `conduit_bank` is
+populated, and `Pathway.map_queryset` filters them out of the
+`/api/plugins/pathways/geo/conduits/` and `/api/plugins/pathways/geo/pathways/`
+GeoJSON endpoints).
+
+To inspect the conduits inside a bank, open the bank detail page in NetBox
+and use the conduits panel.
+
+## Validation
+
+Bank endpoints follow the same rules as any pathway:
+
+- Exactly one start endpoint (structure or location).
+- Exactly one end endpoint (structure or location).
+- The `path` LineString must start and end within 1 metre of the
+  configured structure geometries. The plugin snaps within tolerance and
+  raises `ValidationError` outside it.
+
+Junctions are not valid endpoints for a bank. Banks always run between two
+structures or locations.

--- a/docs/user-guide/junctions.md
+++ b/docs/user-guide/junctions.md
@@ -1,0 +1,99 @@
+# Conduit Junctions
+
+A **Conduit Junction** records a Y-tee where a branch conduit joins a
+trunk conduit at an intermediate point along the trunk's path, rather than
+at one of the trunk's structure endpoints. Junctions are how the data
+model represents mid-span tees, lateral entries, and similar in-line
+splice locations without a manhole.
+
+## When To Use A Junction
+
+A junction is appropriate when:
+
+- A conduit physically branches off another conduit between two
+  structures.
+- There is no manhole, handhole, or other Structure at the branch point.
+- You still need to record where the branch attaches and which way it
+  faces.
+
+If a manhole or handhole exists at the branch point, model that as a
+Structure instead and connect the conduits to it normally. Structures are
+first-class endpoints; junctions are an escape hatch for the cases where
+a Structure does not physically exist.
+
+## Fields
+
+| Field                | Type           | Notes                                                                  |
+|----------------------|----------------|------------------------------------------------------------------------|
+| `label`              | string         | Optional human label.                                                  |
+| `trunk_conduit`      | FK Conduit     | The main conduit being tapped.                                         |
+| `branch_conduit`     | FK Conduit     | The conduit branching off.                                             |
+| `towards_structure`  | FK Structure   | Which end of the trunk the junction faces.                             |
+| `position_on_trunk`  | float `[0, 1]` | Normalised position. `0.0` is the trunk start, `1.0` is the trunk end. |
+
+`towards_structure` must be one of the trunk's two structure endpoints. If
+the trunk uses location or junction endpoints (no Structure on either
+side) you cannot set this field; trying to do so raises
+`ValidationError`.
+
+## How The Branch Conduit Connects
+
+The `branch_conduit` references the junction by setting one of its
+endpoints to that junction (`start_junction` or `end_junction`). Each
+conduit endpoint is one and only one of:
+
+- a `start_structure` / `end_structure`, or
+- a `start_location` / `end_location`, or
+- a `start_junction` / `end_junction`.
+
+`Conduit.clean()` enforces "exactly one" on each side. The junction's
+location is computed from the trunk's geometry at
+`position_on_trunk` (using `LineString.interpolate_normalized`), and the
+branch's path is snapped to that point within 1 metre tolerance.
+
+## Position On Trunk
+
+`position_on_trunk` is a normalised distance, not absolute meters:
+
+| `position_on_trunk` | Meaning                                |
+|---------------------|----------------------------------------|
+| `0.0`               | At the trunk's start endpoint.         |
+| `0.5`               | Halfway along the trunk.               |
+| `1.0`               | At the trunk's end endpoint.           |
+
+The pair `(trunk_conduit, position_on_trunk)` is unique. To put two
+junctions at exactly the same point you would have to nudge one of the
+positions slightly (for example `0.499` vs `0.501`). In practice this is
+rarely needed.
+
+The junction's geographic location is derived, not stored. If the trunk's
+`path` geometry is moved, the junction follows.
+
+## Constraints At A Glance
+
+- `towards_structure` must be one of the trunk's structure endpoints.
+- `position_on_trunk` must be in `[0.0, 1.0]`.
+- The combination of `(trunk_conduit, position_on_trunk)` is unique.
+- Trying to set `towards_structure` on a trunk with no structure
+  endpoints raises a validation error.
+
+## Workflow
+
+1. Create the trunk conduit between two structures.
+2. Create the junction, picking a `position_on_trunk` (e.g. `0.4`) and
+   setting `towards_structure` to whichever trunk endpoint the branch
+   faces.
+3. Create the branch conduit. Set `start_junction` (or `end_junction`)
+   to the new junction. Set the other endpoint to the structure or
+   location where the branch terminates.
+4. Draw the branch conduit's path. The endpoint touching the junction
+   will snap onto the trunk geometry within 1 metre tolerance; outside
+   that, the form returns a validation error.
+
+## Cable Routing Through Junctions
+
+A conduit junction is not itself a routable pathway. When tracing a cable
+through the network, the route follows trunk and branch conduits;
+junctions are joining points that allow the route to switch from trunk
+to branch (or vice versa). The route planner and the cable trace
+endpoint both understand junction adjacency automatically.

--- a/docs/user-guide/map-widget.md
+++ b/docs/user-guide/map-widget.md
@@ -1,0 +1,104 @@
+# Map Widget On Forms
+
+Every model with a geographic field is edited through a Leaflet map widget
+embedded in the NetBox add/edit form. The widget is the same on every
+form; this page covers what you can do with it and how it interacts with
+the rest of the form.
+
+## Where It Appears
+
+| Model            | Geometry field        | Geometry type                 |
+|------------------|-----------------------|-------------------------------|
+| Structure        | `location`            | Point or Polygon              |
+| ConduitBank      | `path`                | LineString                    |
+| Conduit          | `path`                | LineString                    |
+| AerialSpan       | `path`                | LineString                    |
+| DirectBuried     | `path`                | LineString                    |
+| Innerduct        | `path`                | LineString                    |
+| SiteGeometry     | `geometry`            | Point or Polygon              |
+| CircuitGeometry  | `path`                | LineString                    |
+
+The widget configuration (tile layers, default centre, default zoom) is
+read from `PLUGINS_CONFIG['netbox_pathways']`. See
+[Configuration](../getting-started/configuration.md).
+
+## Drawing Tools
+
+The toolbar in the top-left of the widget shows tools appropriate to the
+field's geometry type.
+
+### Points
+
+- **Marker tool** - click anywhere on the map to drop the point. The
+  pin snaps to nearby Structure markers when within ~10 px on screen.
+- **Drag** - move an existing marker by dragging.
+- **Delete** - select the marker and press Delete or use the trash icon
+  in the toolbar.
+
+### LineStrings
+
+- **Line tool** - click to start, click again to add vertices, double-
+  click to finish.
+- **Edit vertices** - click the line, then drag any vertex. Drag the
+  midpoint diamonds to insert a new vertex.
+- **Endpoint snapping** - the first and last vertex snap to the
+  configured start/end Structure (or junction). If the endpoint sits
+  more than 1 metre from the structure, the form rejects it on save.
+
+### Polygons
+
+- **Polygon tool** - click vertices in order, double-click to close.
+- **Edit** - drag vertices or midpoints exactly as for lines. The shape
+  closes automatically.
+
+## Snapping And Tolerance
+
+When you draw or edit a `path`, the plugin's `Pathway.clean()` method
+checks each endpoint against the related Structure or Junction:
+
+- For Point structures, the path endpoint must be within
+  **1.0 metre** of the structure's point. If it is, the endpoint is
+  snapped exactly onto the structure point. If not, you get a
+  `ValidationError` on submit.
+- For Polygon structures, the endpoint must be inside the polygon or
+  within 1.0 metre of its boundary. Endpoints inside the polygon are
+  snapped onto the boundary at the closest point. Outside that
+  tolerance, submit fails.
+- For Junctions, the endpoint must be within 1.0 metre of the
+  junction's location (which is interpolated from the trunk
+  conduit's geometry).
+
+The 1 metre tolerance is in the units of your storage SRID. If you have
+configured a degree-based SRID like `4326`, "1 metre" really means
+"1 degree", which is far too lax. Use a metric projected SRID for
+production deployments. See [SRID Selection](../getting-started/srid.md).
+
+## Coordinate Reference Systems In The Widget
+
+The widget uses Leaflet, which is hard-coded to WGS84. Behind the
+scenes:
+
+1. Stored geometry is read from the database in your storage SRID.
+2. PostGIS transforms it to EPSG:4326 before serialising.
+3. Leaflet displays it.
+4. On save, the widget posts WGS84 GeoJSON; the plugin transforms back
+   to the storage SRID before writing to the database.
+
+You should never have to enter raw coordinates in your storage SRID
+manually. If you do need to (for instance, copying a coordinate from
+another system), the form accepts a WKT/GeoJSON paste in the underlying
+text input that the widget wraps; check for it under the "Show advanced"
+toggle on the widget when present.
+
+## Multiple Base Layers
+
+If `map_base_layers` is configured (typically Mapbox), the widget shows
+a layer control in the top-right where you can switch between Street,
+Light, Dark, and Satellite styles. The selection is per-tab, not
+persisted.
+
+## Detail-Page Mini Maps
+
+Detail pages for the same models embed a smaller, read-only version of
+the same map showing only that record. The mini map uses the same tile
+configuration as the form widget.

--- a/docs/user-guide/route-planner.md
+++ b/docs/user-guide/route-planner.md
@@ -1,0 +1,122 @@
+# Route Planner
+
+The Route Planner finds candidate paths through your pathway network
+between a start endpoint (structure or location) and an end endpoint. It
+operates on the same graph the cable trace uses: structures, locations,
+and junctions are nodes; pathways and bank-to-conduit relationships are
+edges.
+
+The output is one or more **Planned Routes**, ordered lists of pathway
+PKs that you can review, save, edit, and eventually apply to a real
+NetBox `dcim.Cable`.
+
+## Opening The Planner
+
+Navigate to **Plugins > Pathways > Route Planner** or visit
+`/plugins/pathways/route-planner/`.
+
+The planner page shows a map and a sidebar. Pick endpoints either by
+clicking features on the map or by selecting from the dropdowns.
+
+## Endpoints
+
+| Endpoint side | Allowed types                         |
+|---------------|---------------------------------------|
+| Start         | Structure or `dcim.Location`          |
+| End           | Structure or `dcim.Location`          |
+
+A route may start at a Structure and end at a Location (or vice versa);
+this is how the planner finds cross-domain paths between an outdoor
+structure and an indoor wiring closet.
+
+## Constraints
+
+Constraints narrow the search. They are interpreted by
+`/plugins/pathways/route-planner/constraint/` and recorded on the saved
+plan as a JSON snapshot.
+
+| Constraint             | Effect                                                   |
+|------------------------|----------------------------------------------------------|
+| Required pathway       | Force the route to traverse a specific pathway.          |
+| Excluded pathway       | Refuse to use a specific pathway.                        |
+| Tenant filter          | Only use pathways owned by a tenant.                     |
+| Pathway type filter    | Restrict to certain types (e.g. only conduits).          |
+
+The current run's constraint set is shown in the sidebar; you can
+remove a constraint with the X button next to it.
+
+## Running A Search
+
+1. Select start and end endpoints.
+2. Add any constraints.
+3. Click **Find Routes**.
+4. The planner returns up to several candidate routes. Each route lists
+   its pathways in order, total length, hop count, and any pathway types
+   that conflict with your constraints.
+5. Pick the route you want and click **Save**. This creates a
+   `PlannedRoute` record with status `draft`.
+
+## Planned Routes
+
+A Planned Route is a saved route that has not yet been bound to a real
+`dcim.Cable`. Fields:
+
+| Field             | Type             | Notes                                                                |
+|-------------------|------------------|----------------------------------------------------------------------|
+| `name`            | string           | Required. Used as the page title.                                    |
+| `status`          | choice           | `draft`, `approved`, `assigned`, `split`, `archived`.                |
+| `start_structure` | FK Structure     | Either start_structure or start_location must be set, never both.    |
+| `start_location`  | FK Location      |                                                                      |
+| `end_structure`   | FK Structure     | Either end_structure or end_location must be set, never both.        |
+| `end_location`    | FK Location      |                                                                      |
+| `pathway_ids`     | JSON list of int | Ordered list of pathway PKs defining the route.                      |
+| `constraints`     | JSON dict        | Snapshot of the constraints used to generate the route.              |
+| `tenant`          | FK Tenant        | Optional owning tenant.                                              |
+| `cable`           | FK Cable         | Set when the route is applied to a real cable.                       |
+| `parent`          | FK PlannedRoute  | If non-null, this route was split from another route.                |
+
+### Status Transitions
+
+| From       | To           | When                                                |
+|------------|--------------|-----------------------------------------------------|
+| `draft`    | `approved`   | Manual review.                                      |
+| `approved` | `assigned`   | Route applied to a cable.                           |
+| `approved` | `split`      | Route split into child routes for partial install.  |
+| any        | `archived`   | Route is no longer relevant but you want history.   |
+
+The transitions are not enforced by code; the choices help operators
+filter and report.
+
+## Splitting And Reverting
+
+A route can be split into smaller child routes that share the same
+endpoints but cover different segments. Splitting is useful when one
+plan covers the full path but the build will happen in phases.
+
+- `POST /plugins/pathways/planned-routes/<pk>/split/` opens the split
+  form. Children inherit `parent = <pk>` and the parent transitions to
+  `split`.
+- `POST /plugins/pathways/planned-routes/<pk>/revert/` deletes the
+  children and restores the parent to its previous status.
+
+## Applying A Plan To A Cable
+
+When the cable exists in NetBox and is ready for real routing data:
+
+1. Open the Planned Route detail page.
+2. Click **Apply**.
+3. Select the target `dcim.Cable`.
+4. The plugin creates one `CableSegment` per pathway in
+   `pathway_ids`, in order, and sets the route's status to `assigned`.
+
+The cable must already have both A and B terminations recorded in
+NetBox before applying; `CableSegment.clean()` raises a validation error
+otherwise.
+
+## Validation Helper
+
+`PlannedRoute.validate_route()` returns the list of pathway PKs that no
+longer exist in the database. Routes with missing pathways will be
+rejected at apply time. Run this method (via the Django shell, the API,
+or the management UI) before approving a route that has been sitting
+around for a while.

--- a/docs/user-guide/site-geometry.md
+++ b/docs/user-guide/site-geometry.md
@@ -1,0 +1,73 @@
+# Site Geometry
+
+A **Site Geometry** record links a NetBox `dcim.Site` to the Pathways
+geospatial system. It is a thin model with two responsibilities:
+
+1. Hold an explicit boundary or footprint geometry for a Site that is not
+   itself one of your Structures.
+2. Provide a fallback geometry when a Site is "the same physical thing"
+   as a Structure (for example, a single-building site that you also
+   model as a Building Entrance Structure).
+
+## Why It Exists
+
+NetBox's `dcim.Site` does not have a geometry field. The Pathways plugin
+needs a way to anchor data on a Site for two cases:
+
+- The map registry. Other plugins can register layers whose geometry is
+  resolved through `dcim.Site` (see the
+  [Map Layer Registry](../developer/map-layer-registry.md)). The lookup
+  path is `pathways_geometry__geometry`, which only works when a
+  `SiteGeometry` row exists for that site.
+- Drawing site outlines or campus footprints on the map without forcing
+  every site to be modelled as a Structure.
+
+## Fields
+
+| Field      | Type                | Notes                                                                                  |
+|------------|---------------------|----------------------------------------------------------------------------------------|
+| `site`     | OneToOne `dcim.Site`| Required. Each site has at most one geometry record.                                   |
+| `structure`| OneToOne Structure  | Optional. If set, the site "is" this structure.                                        |
+| `geometry` | Point or Polygon    | Optional. Explicit geometry. Auto-populated from `structure.location` if blank on save.|
+| `comments` | text                |                                                                                        |
+
+## Geometry Resolution
+
+The `effective_geometry` property returns the right geometry to use:
+
+1. If `geometry` is set, use it.
+2. Otherwise, if `structure` is set and the structure has a `location`,
+   use `structure.location`.
+3. Otherwise, return `None`.
+
+`SiteGeometry.save()` automatically copies the structure's geometry into
+the explicit `geometry` field if the field is blank when a structure is
+attached. After save, the explicit field is populated, and edits to the
+structure no longer feed back automatically. Re-link the structure or
+clear the `geometry` field if you want to refresh the copy.
+
+## When To Create A Site Geometry
+
+| Situation                                                              | Create one? |
+|------------------------------------------------------------------------|-------------|
+| You want to draw a site polygon on the Pathways map.                   | Yes.        |
+| Another plugin's models reference `dcim.Site` and need map placement.  | Yes.        |
+| The site is identical to a single Structure you already created.       | Optional. Helpful for plugins doing reverse lookups; otherwise the Structure alone is enough. |
+| You only ever route through Structures inside the site, not the site itself. | No.   |
+
+## Map Display
+
+Site polygons render with a 20% fill opacity and the layer's stroke
+colour. They are not toggled on by default and must be wired through a
+registered map layer (typically by your own plugin) to appear on the
+map.
+
+The plugin's first-party map does not show site geometries directly; the
+feature exists primarily as the geometry source for cross-plugin layers.
+
+## Forms
+
+Create or edit a `SiteGeometry` at
+`/plugins/pathways/site-geometries/`. The form uses the standard map
+widget, so you can click the map to drop a point or use the polygon tool
+to draw a footprint.


### PR DESCRIPTION
Substantive expansion of the documentation site, generated by a per-plugin exploration pass that traced models, views, REST API, backends, and management commands. Covers user workflows, configuration references, REST API, and developer guides.

Drafted as PRs to land iteratively -- review piece by piece, edit / drop pages where the prose doesn't match operator reality, trim things better suited to code comments. The agent that drafted this had less context than you do; treat as a starting point.

ASCII-only output, no AI / Claude attribution. Conventional-commits PR title.