### PR TITLE
feat(import): honor null_values spec when mapping fields

### DIFF
--- a/netbox_pathways/management/commands/import_geodata.py
+++ b/netbox_pathways/management/commands/import_geodata.py
@@ -57,6 +57,27 @@ TRANSFORMS = {
 }
 
 
+def _matches_null_value(value, null_values):
+    """Return True if value should be treated as null per the null_values list.
+
+    Compares numerically when both sides are coercible to float (so 0 == 0.0 == "0"),
+    and falls back to stripped string equality for non-numeric sentinels like "N/A".
+    """
+    if value is None:
+        return True
+    for nv in null_values:
+        if nv is None:
+            continue
+        try:
+            if float(value) == float(nv):
+                return True
+        except (TypeError, ValueError):
+            pass
+        if str(value).strip() == str(nv):
+            return True
+    return False
+
+
 def _deserialize_kwargs(row, geom_field):
     """Reconstruct kwargs from serialized row (EWKT geometry, FK tuples)."""
     from django.apps import apps
@@ -380,6 +401,8 @@ class Command(BaseCommand):
                         value = raw.get(src_field)
                         if value is None or not str(value).strip():
                             continue
+                        if "null_values" in spec and _matches_null_value(value, spec["null_values"]):
+                            continue
                         transform_name = spec.get("transform")
                         if transform_name:
                             transform_fn = TRANSFORMS.get(transform_name)
@@ -663,11 +686,16 @@ class Command(BaseCommand):
     def _apply_field_spec(self, value, spec):
         """Apply a field specification to transform a source value.
 
-        Processing order: regex → map → transform → format.
-        Each step feeds into the next if both are present.
+        Processing order: null_values -> regex -> map -> transform -> format.
+        Each step feeds into the next if both are present. A null_values match
+        short-circuits and returns None (the field is left unset on the model).
         """
         if not isinstance(spec, dict):
             return value
+
+        # Null sentinel detection (short-circuits the rest of the pipeline)
+        if "null_values" in spec and _matches_null_value(value, spec["null_values"]):
+            return None
 
         # Regex extraction
         if "regex" in spec:

--- a/tests/test_import_geodata.py
+++ b/tests/test_import_geodata.py
@@ -1,0 +1,36 @@
+from netbox_pathways.management.commands.import_geodata import _matches_null_value
+
+
+class TestMatchesNullValue:
+    def test_value_python_none_matches(self):
+        assert _matches_null_value(None, [0]) is True
+
+    def test_zero_float_matches_int_zero_sentinel(self):
+        assert _matches_null_value(0.0, [0]) is True
+
+    def test_zero_int_matches_float_zero_sentinel(self):
+        assert _matches_null_value(0, [0.0]) is True
+
+    def test_string_zero_matches_numeric_sentinel(self):
+        assert _matches_null_value("0", [0.0]) is True
+        assert _matches_null_value("0.0", [0]) is True
+
+    def test_non_numeric_sentinel_string_match(self):
+        assert _matches_null_value("N/A", ["N/A"]) is True
+
+    def test_negative_sentinel(self):
+        assert _matches_null_value(-1, [-1, 9999]) is True
+
+    def test_nonzero_value_does_not_match_zero_sentinels(self):
+        assert _matches_null_value(1.5, [0, 0.0]) is False
+
+    def test_nonmatching_string_does_not_match(self):
+        assert _matches_null_value("hello", [0]) is False
+
+    def test_empty_null_values_returns_false(self):
+        assert _matches_null_value(0.0, []) is False
+
+    def test_none_in_null_values_list_is_skipped(self):
+        # None entries in the list should be ignored, not crash
+        assert _matches_null_value(0, [None, 0]) is True
+        assert _matches_null_value(1, [None]) is False


### PR DESCRIPTION
## Summary

- Adds a `_matches_null_value` helper to the GeoJSON / shapefile importer so per-field `null_values` lists in the import spec are actually honored when mapping source columns to model fields.
- Numeric comparisons coerce both sides to `float` so `0`, `0.0`, and `"0"` all match a numeric sentinel like `0`. Non-numeric sentinels (e.g. `"N/A"`, `"Unknown"`) match by stripped-string equality. `None` entries in the list are skipped.
- Wired into `_apply_field_spec` ahead of the regex / map / transform / format pipeline so a null match short-circuits to `None` and the target field is left unset on the model. Also short-circuits in the per-row mapping loop so the field is skipped before any transform runs.

## Why

ESRI / ArcGIS exports commonly use `0` as a null sentinel on numeric columns and strings like `"N/A"` or `"Unknown"` on text columns. Without honoring `null_values`, the importer treated those literally -- e.g. fibre-count `0` got written as a real `0` rather than left null, and `"Unknown"` ended up as the cable owner string.

## Changes

- `netbox_pathways/management/commands/import_geodata.py`: add `_matches_null_value` helper; consult `spec["null_values"]` in both the row-mapping loop and `_apply_field_spec`.
- `tests/test_import_geodata.py` (new): 10 unit tests covering numeric coercion, non-numeric strings, negative sentinels, empty list, and `None` entries.

## Testing

- [x] `pytest tests/test_import_geodata.py` -- 10 passed
- [x] `ruff check` passes
- [x] `ruff format --check` passes

## Related

Prep for the ESRI cross-walk feature work tracked in #4.