### PR TITLE
fix(srid): align 0004 with get_srid() and add column-drift check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`CircuitGeometry.path` SRID drift** -- `0004_circuit_geometry` no longer hardcodes `srid=3348`; it now uses `_SRID = get_srid()` like the other migrations, so the column SRID follows `PLUGINS_CONFIG['netbox_pathways']['srid']`. Installs whose configured SRID differs from `3348` were silently storing the path column at `3348` and rejecting every form submission with `Geometry SRID does not match column SRID` (issue #5, #29).
+
+### Added
+
+- **System check `netbox_pathways.E001`** -- compares introspected `geometry_columns` SRIDs against `get_srid()` and emits a `checks.Error` (with remediation hint) whenever a stored column SRID disagrees with the configured value. Runs on `manage.py check` and `manage.py migrate`. Catches the same drift surfaced in #5/#29 before users hit it through the UI.
+
 ## [0.2.0] - 2026-05-06
 
 ### Added

--- a/netbox_pathways/__init__.py
+++ b/netbox_pathways/__init__.py
@@ -89,8 +89,12 @@ class NetBoxPathwaysConfig(PluginConfig):
 
         super().ready()
 
-        # Register signals
+        from django.core.checks import register
+
         from . import signals  # noqa: F401
+        from .checks import check_geometry_column_srids
+
+        register(check_geometry_column_srids)
 
         logger.info("%s plugin loaded", self.name)
 

--- a/netbox_pathways/checks.py
+++ b/netbox_pathways/checks.py
@@ -1,0 +1,86 @@
+"""
+System checks for the netbox_pathways plugin.
+
+The storage SRID is baked into PostGIS columns at migrate time, but
+get_srid() is read from PLUGINS_CONFIG at form/serializer save time. If
+the two ever drift apart -- either because a migration shipped with a
+hardcoded SRID, or because an operator edited PLUGINS_CONFIG after
+applying migrations -- inserts fail with a SRID mismatch and crash the
+end user back to the home page (see issue #5).
+
+This module introspects geometry_columns and emits a checks.Error for
+every column whose stored SRID does not match get_srid(), with a hint
+that points at both remediation paths (revert config, or write an
+ST_Transform migration).
+"""
+
+from django.apps import apps
+from django.core.checks import Error
+from django.db import connection
+from django.db.utils import OperationalError, ProgrammingError
+
+from .geo import get_srid
+
+CHECK_ID = "netbox_pathways.E001"
+
+
+def _introspect_column_srids(connection, app_label):
+    """Return {(table, column): srid} for geometry columns in the app's tables."""
+    if connection.vendor != "postgresql":
+        return {}
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT f_table_name, f_geometry_column, srid FROM geometry_columns WHERE f_table_name LIKE %s",
+                [f"{app_label}_%"],
+            )
+            return {(row[0], row[1]): row[2] for row in cursor.fetchall()}
+    except (OperationalError, ProgrammingError):
+        return {}
+
+
+def check_geometry_column_srids(app_configs=None, **kwargs):
+    """Compare introspected column SRIDs to PLUGINS_CONFIG['netbox_pathways']['srid']."""
+    from django.core.exceptions import ImproperlyConfigured
+
+    try:
+        expected_srid = get_srid()
+    except ImproperlyConfigured:
+        return []
+
+    actual = _introspect_column_srids(connection, "netbox_pathways")
+    if not actual:
+        return []
+
+    try:
+        models = apps.get_app_config("netbox_pathways").get_models()
+    except LookupError:
+        return []
+
+    errors = []
+    for model in models:
+        table = model._meta.db_table
+        for field in model._meta.get_fields():
+            if not hasattr(field, "srid") or field.srid is None:
+                continue
+            actual_srid = actual.get((table, field.column))
+            if actual_srid is None or actual_srid == expected_srid:
+                continue
+            errors.append(
+                Error(
+                    f"Geometry column {table}.{field.column} has SRID {actual_srid}, "
+                    f"but PLUGINS_CONFIG['netbox_pathways']['srid'] is {expected_srid}. "
+                    "Form submissions and API writes will fail with 'Geometry SRID does "
+                    "not match column SRID'.",
+                    hint=(
+                        "Storage SRID is immutable after migrations apply. Either "
+                        f"set PLUGINS_CONFIG['netbox_pathways']['srid'] = {actual_srid} "
+                        "to match the existing columns, or write a data migration that "
+                        f"runs ST_Transform(<column>, {expected_srid}) on every affected "
+                        "row before re-typing the column."
+                    ),
+                    id=CHECK_ID,
+                    obj=model,
+                )
+            )
+    return errors

--- a/netbox_pathways/migrations/0004_circuit_geometry.py
+++ b/netbox_pathways/migrations/0004_circuit_geometry.py
@@ -7,6 +7,10 @@ import taggit.managers
 import utilities.json
 from django.db import migrations, models
 
+from netbox_pathways.geo import get_srid
+
+_SRID = get_srid()
+
 
 class Migration(migrations.Migration):
 
@@ -24,7 +28,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True, null=True)),
                 ('last_updated', models.DateTimeField(auto_now=True, null=True)),
                 ('custom_field_data', models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder)),
-                ('path', django.contrib.gis.db.models.fields.LineStringField(srid=3348)),
+                ('path', django.contrib.gis.db.models.fields.LineStringField(srid=_SRID)),
                 ('provider_reference', models.CharField(blank=True, max_length=200)),
                 ('comments', models.TextField(blank=True)),
                 ('circuit', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='pathways_route', to='circuits.circuit')),

--- a/tests/test_srid_checks.py
+++ b/tests/test_srid_checks.py
@@ -1,0 +1,73 @@
+"""Tests for SRID drift system check and migration consistency."""
+
+import importlib
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+from django.core.checks import Error
+from django.db import connection
+from django.db.utils import ProgrammingError
+
+from netbox_pathways.checks import (
+    _introspect_column_srids,
+    check_geometry_column_srids,
+)
+
+
+class TestMigrationSrid:
+    """Migrations must derive SRID from get_srid(), never from a literal."""
+
+    def test_circuit_geometry_path_srid_follows_config(self, settings):
+        settings.PLUGINS_CONFIG = deepcopy(settings.PLUGINS_CONFIG)
+        settings.PLUGINS_CONFIG.setdefault("netbox_pathways", {})["srid"] = 3857
+
+        mod = importlib.import_module("netbox_pathways.migrations.0004_circuit_geometry")
+        importlib.reload(mod)
+
+        operation = mod.Migration.operations[0]
+        fields_dict = dict(operation.fields)
+        assert fields_dict["path"].srid == 3857
+
+
+class TestIntrospectColumnSrids:
+    def test_returns_empty_for_non_postgres(self):
+        fake_conn = MagicMock()
+        fake_conn.vendor = "sqlite"
+        assert _introspect_column_srids(fake_conn, "netbox_pathways") == {}
+
+    def test_returns_empty_on_db_error(self):
+        fake_conn = MagicMock()
+        fake_conn.vendor = "postgresql"
+        cursor = fake_conn.cursor.return_value.__enter__.return_value
+        cursor.execute.side_effect = ProgrammingError("relation does not exist")
+        assert _introspect_column_srids(fake_conn, "netbox_pathways") == {}
+
+    def test_introspects_real_columns(self, db):
+        result = _introspect_column_srids(connection, "netbox_pathways")
+        assert ("netbox_pathways_structure", "location") in result
+
+
+class TestCheckGeometryColumnSrids:
+    def test_silent_when_srid_unconfigured(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        with patch("netbox_pathways.checks.get_srid", side_effect=ImproperlyConfigured()):
+            assert check_geometry_column_srids() == []
+
+    def test_silent_when_no_columns_introspected(self):
+        with patch("netbox_pathways.checks._introspect_column_srids", return_value={}):
+            assert check_geometry_column_srids() == []
+
+    def test_no_errors_when_columns_match_config(self, db):
+        assert check_geometry_column_srids() == []
+
+    def test_reports_error_on_mismatch(self, db):
+        with patch("netbox_pathways.checks.get_srid", return_value=999):
+            errors = check_geometry_column_srids()
+        assert errors, "expected at least one mismatch error"
+        assert all(isinstance(e, Error) for e in errors)
+        assert all(e.id == "netbox_pathways.E001" for e in errors)
+        first = errors[0]
+        assert "999" in first.msg
+        assert "PLUGINS_CONFIG" in first.hint
+        assert "ST_Transform" in first.hint


### PR DESCRIPTION
## Summary

- Patch `0004_circuit_geometry.py` to use `_SRID = get_srid()` like every other migration, instead of the hardcoded `srid=3348` that was silently breaking every install whose configured SRID was not 3348 (the symptom in https://github.com/jsenecal/netbox-pathways/issues/5#issuecomment-4393145250).
- Add a Django system check (`netbox_pathways.E001`) that introspects `geometry_columns` and reports a `checks.Error` for every column whose stored SRID disagrees with the current `get_srid()`, with a remediation hint covering both paths (revert config or write an `ST_Transform` migration).

Fixes #29. Refs https://github.com/jsenecal/netbox-pathways/issues/5#issuecomment-4393145250.

## Changes

- `netbox_pathways/migrations/0004_circuit_geometry.py`: replace `srid=3348` literal with `_SRID = get_srid()` pattern.
- `netbox_pathways/checks.py` (new): `_introspect_column_srids()` queries `geometry_columns`; `check_geometry_column_srids()` compares each plugin model's geometry fields against the stored SRID and returns `Error`s with id `netbox_pathways.E001`. Silent on non-postgres connections, missing config, or empty introspection.
- `netbox_pathways/__init__.py`: register the check in `PluginConfig.ready()` so it runs on `manage.py check` and `manage.py migrate`.
- `tests/test_srid_checks.py` (new): 8 tests covering migration uses `get_srid()` (regression test for #29), introspection on real columns and on mocked failure modes (non-postgres, `ProgrammingError`), and the check's silent-vs-loud branches including the mismatch path with id and hint assertions.
- `CHANGELOG.md`: `[Unreleased]` Fixed and Added entries.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (233 passed, including 8 new)
- [x] New regression test in `TestMigrationSrid` fails on the unpatched migration and passes after
- [x] `python manage.py check` runs clean against a dev DB whose column SRIDs match `PLUGINS_CONFIG`
- [x] Manual: drift a column via `ALTER TABLE ... ALTER COLUMN path TYPE geometry(LineString, 4326) USING ST_Transform(path, 4326)` and confirm `manage.py check` reports `netbox_pathways.E001` (skipped here -- prefer to verify on a throwaway database before promoting)
- [x] Migration applied cleanly on a fresh install with non-3348 SRID

## Notes for reviewers

The migration fix changes a previously-applied migration's source. For installs that already migrated under the old hardcoded `srid=3348`, this fix alone does not move existing data -- it only ensures fresh installs behave correctly. Operators on existing installs who configured a different SRID will see `netbox_pathways.E001` reported by the new check, with a hint pointing at the `ST_Transform` migration they need. A follow-up data-migration helper could be considered if this turns out to be a common situation.

## Related

Refs: https://github.com/jsenecal/netbox-pathways/issues/5#issuecomment-4393145250
Fixes: #29