### PR TITLE
chore: bump version 0.2.0 -> 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-07
+
 ### Fixed
 
 - **`CircuitGeometry.path` SRID drift** -- `0004_circuit_geometry` no longer hardcodes `srid=3348`; it now uses `_SRID = get_srid()` like the other migrations, so the column SRID follows `PLUGINS_CONFIG['netbox_pathways']['srid']`. Installs whose configured SRID differs from `3348` were silently storing the path column at `3348` and rejecting every form submission with `Geometry SRID does not match column SRID` (issue #5, #29).

--- a/netbox_pathways/__init__.py
+++ b/netbox_pathways/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from netbox.plugins import PluginConfig
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ netbox_pathways = [
 
 [project]
 name = "netbox-pathways"
-version = "0.2.0"
+version = "0.2.1"
 description = "NetBox plugin for physical cable plant infrastructure documentation with GIS capabilities"
 readme = "README.md"
 authors = [
@@ -60,7 +60,7 @@ Tracker = "https://github.com/jsenecal/netbox-pathways/issues"
 Documentation = "https://jsenecal.github.io/netbox-pathways/"
 
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.2.1"
 commit = true
 tag = true
 tag_name = "v{new_version}"


### PR DESCRIPTION
## Summary

- Patch release **0.2.1** rolling up the SRID drift fix and the new `netbox_pathways.E001` system check landed in #30 (Refs #5, #29).
- Promotes `[Unreleased]` to `[0.2.1] - 2026-05-07` in `CHANGELOG.md` and bumps `pyproject.toml` / `netbox_pathways.__version__`.
- Tag `v0.2.1` points at the bump commit and will trigger `publish.yml` to push to PyPI on merge.

## Changes

- `CHANGELOG.md`: promote `[Unreleased]` to `[0.2.1] - 2026-05-07` (Fixed: SRID drift in `0004_circuit_geometry`; Added: `netbox_pathways.E001` system check).
- `pyproject.toml`: `version` and `[tool.bumpversion].current_version` 0.2.0 -> 0.2.1.
- `netbox_pathways/__init__.py`: `__version__` 0.2.0 -> 0.2.1.

## Testing

- [x] `bump-my-version bump patch --allow-dirty` ran clean (no source code changes -- release-only bump).
- [x] CI green (ruff check, ruff format --check, pytest).
- [x] `CHANGELOG.md` updated.
- [x] No migration changes (release-only).

## Related

Refs: #5, #29