### PR TITLE
chore(github): adopt canonical labels and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a bug or unexpected behavior in this plugin
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in every required
+        field so the maintainers can reproduce the issue. Tracebacks and exact
+        version numbers help much more than a screenshot.
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: Run `pip show <plugin>` inside the NetBox venv, or check `pyproject.toml`.
+      placeholder: "0.5.2"
+    validations:
+      required: true
+  - type: input
+    id: netbox-version
+    attributes:
+      label: NetBox version
+      description: Shown at the bottom of the NetBox UI or via `GET /api/status/`.
+      placeholder: "4.5.10"
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12.x"
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal ordered steps that reliably trigger the bug.
+      placeholder: |
+        1. Navigate to ...
+        2. Click on ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include any tracebacks from the NetBox logs.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, related configuration, links to relevant code, anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: NetBox upstream
+    url: https://github.com/netbox-community/netbox/issues
+    about: Report bugs or feature requests for NetBox itself (not this plugin).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement. Describe the problem first, then the
+        solution -- a clear problem statement is the most useful thing you can
+        provide.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve? Why is the current behavior insufficient?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen? Be as concrete as possible (UI mockups, API shapes, etc.).
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why you set them aside.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Use cases, links to related issues, references to similar features in other tools.
+    validations:
+      required: false

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -46,7 +46,7 @@ categories:
   - title: "CI / build"
     labels: [ci, build]
   - title: "Other changes"
-    labels: [chore, revert]
+    labels: [housekeeping, revert]
 
 exclude-labels:
   - skip-changelog
@@ -74,7 +74,7 @@ autolabeler:
   - label: docs
     title:
       - '/^docs(\(.+\))?:/i'
-  - label: chore
+  - label: housekeeping
     title:
       - '/^chore(\(.+\))?:/i'
   - label: refactor
@@ -102,5 +102,5 @@ version-resolver:
   minor:
     labels: [feat, feature, minor, enhancement]
   patch:
-    labels: [fix, bug, chore, refactor, docs, ci, build, test, perf, revert, patch, dependencies]
+    labels: [fix, bug, housekeeping, refactor, docs, ci, build, test, perf, revert, patch, dependencies]
   default: patch


### PR DESCRIPTION
## Summary
- release-drafter autolabeler/version-resolver now emit `housekeeping` instead of `chore` for `chore(...):` PRs. PR title format unchanged; only the resulting label name differs.
- Adopt the canonical YAML issue forms (bug_report, feature_request, config) shared across the 8 owned plugins.

## Changes
- `.github/release-drafter.yml`: autolabeler emits `housekeeping`; `housekeeping` added to the "Other changes" category and the version-resolver patch bucket (replacing `chore`).
- `.github/ISSUE_TEMPLATE/bug_report.yml`: structured YAML issue form with Plugin version + NetBox version + Python version + repro/expected/actual.
- `.github/ISSUE_TEMPLATE/feature_request.yml`: problem statement + proposed solution + alternatives.
- `.github/ISSUE_TEMPLATE/config.yml`: disables blank issues; points NetBox-core bugs upstream.

## Testing
- `gh label list` confirms `housekeeping` exists on this repo (renamed from `chore`, all prior issue associations preserved).
- release-drafter.yml schema unchanged; only label names rewritten.

## Related
Cross-plugin normalization. The label set itself was synced via `scripts/sync-labels.py` in the `netbox-plugins` meta-repo.