### PR TITLE
test: improve coverage on plugin-owned logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 ![Status](https://img.shields.io/badge/status-alpha-orange)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
+> Local coverage note: `pytest --cov` run inside the devcontainer
+> against `/opt/netbox/venv` may report 0% due to an editable-install
+> / Django app-load timing quirk. For accurate local coverage use
+> `uv venv && source .venv/bin/activate && uv pip install -e ".[dev]" && pytest --cov=netbox_pathways`,
+> or rely on the Codecov upload from CI.
+
 ## Features
 
 - **Structures** -- poles, manholes, cabinets, equipment rooms, and more with PostGIS geometry (point or polygon).

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,4 +108,4 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=netbox_pathways --cov-report=term-missing --reuse-db"
+addopts = "-v --cov=netbox_pathways --cov-report=term-missing --cov-fail-under=65 --reuse-db"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,68 @@ def admin_user(db):
     )
 
 
+def build_cable_with_terminations(*, label, site, terminate_a=True, terminate_b=True):
+    """Build a Cable with optional A-/B-side terminations rooted in `site`.
+
+    Each side is wired to an Interface on a Device in `site`, which causes
+    `CableTermination.cache_related_objects()` to populate `_site` from
+    `termination.device.site` on save. Used by tests that exercise view
+    helpers which resolve cable terminations to graph nodes.
+    """
+    from dcim.models import (
+        Cable,
+        CableTermination,
+        Device,
+        DeviceRole,
+        DeviceType,
+        Interface,
+        Manufacturer,
+    )
+    from django.contrib.contenttypes.models import ContentType
+
+    mfr, _ = Manufacturer.objects.get_or_create(name="RP-mfr", slug="rp-mfr")
+    dt, _ = DeviceType.objects.get_or_create(
+        manufacturer=mfr,
+        model="RP-dt",
+        slug="rp-dt",
+    )
+    dr, _ = DeviceRole.objects.get_or_create(name="RP-dr", slug="rp-dr")
+
+    cable = Cable.objects.create(label=label)
+    iface_ct = ContentType.objects.get_for_model(Interface)
+
+    if terminate_a:
+        dev_a = Device.objects.create(
+            name=f"{label}-devA",
+            device_type=dt,
+            role=dr,
+            site=site,
+        )
+        iface_a = Interface.objects.create(name="eth0", device=dev_a, type="1000base-t")
+        CableTermination.objects.create(
+            cable=cable,
+            cable_end="A",
+            termination_type=iface_ct,
+            termination_id=iface_a.pk,
+        )
+    if terminate_b:
+        dev_b = Device.objects.create(
+            name=f"{label}-devB",
+            device_type=dt,
+            role=dr,
+            site=site,
+        )
+        iface_b = Interface.objects.create(name="eth0", device=dev_b, type="1000base-t")
+        CableTermination.objects.create(
+            cable=cable,
+            cable_end="B",
+            termination_type=iface_ct,
+            termination_id=iface_b.pk,
+        )
+
+    return cable
+
+
 @pytest.fixture(autouse=True)
 def _clean_registry():
     """Ensure each test starts with a clean registry."""

--- a/tests/test_cable_routing_views.py
+++ b/tests/test_cable_routing_views.py
@@ -299,3 +299,161 @@ class TestRenderTable:
         assert response.status_code == 200
         # The template renders an empty-state message rather than the table
         assert b"No segments in this cable" in response.content
+
+
+# ---------------------------------------------------------------------------
+# CableRoutingAddSegmentView.post
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAddSegmentPost:
+    @pytest.fixture(autouse=True)
+    def _no_routability_check(self, _disable_routability_signal):
+        yield
+
+    def test_creates_first_segment_with_sequence_one(self, factory, admin_user, linear_topology):
+        from dcim.models import Cable
+
+        from netbox_pathways.views import CableRoutingAddSegmentView
+
+        cable = Cable.objects.create(label="CR-add-first")
+        p1 = linear_topology["p1"]
+        request = factory.post(
+            f"/pathways/cable/{cable.pk}/routing/add/",
+            data={"pathway": str(p1.pk)},
+        )
+        request.user = admin_user
+
+        response = CableRoutingAddSegmentView().post(request, cable_pk=cable.pk)
+        assert response.status_code == 200
+
+        segments = list(CableSegment.objects.filter(cable=cable).order_by("sequence"))
+        assert len(segments) == 1
+        assert segments[0].sequence == 1
+        assert segments[0].pathway_id == p1.pk
+
+    def test_after_sequence_inserts_and_shifts_later_segments(self, factory, admin_user, linear_topology):
+        from dcim.models import Cable
+
+        from netbox_pathways.views import CableRoutingAddSegmentView
+
+        cable = Cable.objects.create(label="CR-add-shift")
+        p1 = linear_topology["p1"]
+        p2 = linear_topology["p2"]
+
+        # Seed two segments at sequences 1 and 2
+        seg1 = CableSegment.objects.create(cable=cable, pathway=p1, sequence=1)
+        seg2 = CableSegment.objects.create(cable=cable, pathway=p2, sequence=2)
+
+        request = factory.post(
+            f"/pathways/cable/{cable.pk}/routing/add/",
+            data={"pathway": str(p1.pk), "after_sequence": "1"},
+        )
+        request.user = admin_user
+
+        response = CableRoutingAddSegmentView().post(request, cable_pk=cable.pk)
+        assert response.status_code == 200
+
+        segments = list(CableSegment.objects.filter(cable=cable).order_by("sequence"))
+        assert len(segments) == 3
+        # seg1 still at sequence 1
+        seg1.refresh_from_db()
+        assert seg1.sequence == 1
+        # new segment inserted at sequence 2 with pathway p1
+        assert segments[1].sequence == 2
+        assert segments[1].pathway_id == p1.pk
+        assert segments[1].pk not in (seg1.pk, seg2.pk)
+        # previously-at-2 segment shifted to 3
+        seg2.refresh_from_db()
+        assert seg2.sequence == 3
+
+
+# ---------------------------------------------------------------------------
+# CableRoutingDeleteSegmentView.post
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDeleteSegmentPost:
+    @pytest.fixture(autouse=True)
+    def _no_routability_check(self, _disable_routability_signal):
+        yield
+
+    def test_deletes_specified_segment_and_returns_table(self, factory, admin_user, linear_topology):
+        from dcim.models import Cable
+
+        from netbox_pathways.views import CableRoutingDeleteSegmentView
+
+        cable = Cable.objects.create(label="CR-del")
+        seg = CableSegment.objects.create(
+            cable=cable,
+            pathway=linear_topology["p1"],
+            sequence=1,
+        )
+
+        request = factory.post(f"/pathways/cable/{cable.pk}/routing/delete/{seg.pk}/")
+        request.user = admin_user
+
+        response = CableRoutingDeleteSegmentView().post(request, cable_pk=cable.pk, segment_pk=seg.pk)
+        assert response.status_code == 200
+        assert not CableSegment.objects.filter(pk=seg.pk).exists()
+
+
+# ---------------------------------------------------------------------------
+# CableRoutingApplyRouteView.post
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestApplyRoutePost:
+    @pytest.fixture(autouse=True)
+    def _no_routability_check(self, _disable_routability_signal):
+        yield
+
+    def test_replaces_existing_segments_with_pathway_ids(self, factory, admin_user, linear_topology):
+        from dcim.models import Cable
+
+        from netbox_pathways.views import CableRoutingApplyRouteView
+
+        cable = Cable.objects.create(label="CR-apply")
+        p1 = linear_topology["p1"]
+        p2 = linear_topology["p2"]
+
+        # Pre-existing segment at p2 only
+        CableSegment.objects.create(cable=cable, pathway=p2, sequence=1)
+
+        request = factory.post(
+            f"/pathways/cable/{cable.pk}/routing/apply/",
+            data={"pathway_ids": f"{p1.pk},{p2.pk}"},
+        )
+        request.user = admin_user
+
+        response = CableRoutingApplyRouteView().post(request, cable_pk=cable.pk)
+        assert response.status_code == 200
+
+        segments = list(CableSegment.objects.filter(cable=cable).order_by("sequence"))
+        assert [s.sequence for s in segments] == [1, 2]
+        assert [s.pathway_id for s in segments] == [p1.pk, p2.pk]
+
+    def test_empty_pathway_ids_clears_all_segments(self, factory, admin_user, linear_topology):
+        from dcim.models import Cable
+
+        from netbox_pathways.views import CableRoutingApplyRouteView
+
+        cable = Cable.objects.create(label="CR-apply-empty")
+        CableSegment.objects.create(
+            cable=cable,
+            pathway=linear_topology["p1"],
+            sequence=1,
+        )
+
+        request = factory.post(
+            f"/pathways/cable/{cable.pk}/routing/apply/",
+            data={"pathway_ids": ""},
+        )
+        request.user = admin_user
+
+        response = CableRoutingApplyRouteView().post(request, cable_pk=cable.pk)
+        assert response.status_code == 200
+        assert CableSegment.objects.filter(cable=cable).count() == 0

--- a/tests/test_cable_routing_views.py
+++ b/tests/test_cable_routing_views.py
@@ -240,7 +240,7 @@ class TestStartEndNode:
             site=site,
             location=Point(0, 0, srid=SRID),
         )
-        Structure.objects.create(
+        s2 = Structure.objects.create(
             name="CR-multi-2",
             site=site,
             location=Point(10, 10, srid=SRID),
@@ -253,8 +253,11 @@ class TestStartEndNode:
             terminate_b=False,
         )
         result = mixin._start_node(cable)
-        # Either structure can win first(); both are valid graph nodes for the site
-        assert result == ("structure", s1.pk) or result[0] == "structure"
+        # Either structure can win first(); pin to one of the two known PKs.
+        assert result is not None
+        kind, pk = result
+        assert kind == "structure"
+        assert pk in {s1.pk, s2.pk}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cable_routing_views.py
+++ b/tests/test_cable_routing_views.py
@@ -1,0 +1,301 @@
+"""Tests for cable routing panel view helpers."""
+
+import pytest
+from django.contrib.gis.geos import LineString, Point
+from django.test import RequestFactory
+
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import CableSegment, Pathway, Structure
+from netbox_pathways.views import CableRoutingMixin, _annotate_segments
+from tests.conftest import build_cable_with_terminations
+
+SRID = get_srid()
+
+
+@pytest.fixture
+def factory():
+    return RequestFactory()
+
+
+@pytest.fixture
+def _disable_routability_signal():
+    """Disconnect the pre_save routability check so we can build orphan segments.
+
+    The CableSegment routability signal requires both A and B cable terminations
+    before saving. These tests focus on view helpers and shouldn't have to wire
+    full Cable + CableTermination + Device fixtures for every segment.
+    """
+    from django.db.models.signals import pre_save
+
+    from netbox_pathways.signals import enforce_cable_routability
+
+    pre_save.disconnect(enforce_cable_routability, sender=CableSegment)
+    yield
+    pre_save.connect(enforce_cable_routability, sender=CableSegment)
+
+
+@pytest.fixture
+def linear_topology(db):
+    """Three structures linked by two pathways: A -- P1 -- B -- P2 -- C."""
+    a = Structure.objects.create(name="A", location=Point(0, 0, srid=SRID))
+    b = Structure.objects.create(name="B", location=Point(100, 0, srid=SRID))
+    c = Structure.objects.create(name="C", location=Point(200, 0, srid=SRID))
+    p1 = Pathway.objects.create(
+        label="P1",
+        pathway_type="conduit",
+        path=LineString((0, 0), (100, 0), srid=SRID),
+        start_structure=a,
+        end_structure=b,
+    )
+    p2 = Pathway.objects.create(
+        label="P2",
+        pathway_type="conduit",
+        path=LineString((100, 0), (200, 0), srid=SRID),
+        start_structure=b,
+        end_structure=c,
+    )
+    return {"a": a, "b": b, "c": c, "p1": p1, "p2": p2}
+
+
+# ---------------------------------------------------------------------------
+# _far_end_node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestFarEndNode:
+    def test_returns_end_when_entering_from_start(self, linear_topology):
+        mixin = CableRoutingMixin()
+        p1 = linear_topology["p1"]
+        a = linear_topology["a"]
+        result = mixin._far_end_node(p1, coming_from_node=("structure", a.pk))
+        assert result == ("structure", linear_topology["b"].pk)
+
+    def test_returns_start_when_entering_from_end(self, linear_topology):
+        mixin = CableRoutingMixin()
+        p1 = linear_topology["p1"]
+        b = linear_topology["b"]
+        result = mixin._far_end_node(p1, coming_from_node=("structure", b.pk))
+        assert result == ("structure", linear_topology["a"].pk)
+
+    def test_no_coming_from_returns_end(self, linear_topology):
+        # Default case: when coming_from is None, return the canonical end node.
+        mixin = CableRoutingMixin()
+        result = mixin._far_end_node(linear_topology["p1"])
+        assert result == ("structure", linear_topology["b"].pk)
+
+
+# ---------------------------------------------------------------------------
+# _annotate_segments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAnnotateSegments:
+    @pytest.fixture(autouse=True)
+    def _no_routability_check(self, _disable_routability_signal):
+        yield
+
+    def test_empty_list_is_no_op(self):
+        segments = []
+        _annotate_segments(segments)
+        assert segments == []
+
+    def test_annotates_each_segment(self, linear_topology):
+        from dcim.models import Cable
+
+        cable = Cable.objects.create()
+        seg1 = CableSegment.objects.create(
+            cable=cable,
+            pathway=linear_topology["p1"],
+            sequence=1,
+        )
+        seg2 = CableSegment.objects.create(
+            cable=cable,
+            pathway=linear_topology["p2"],
+            sequence=2,
+        )
+        segments = [seg1, seg2]
+        _annotate_segments(segments)
+
+        # ordinal: 1-based index in the list
+        assert seg1.ordinal == 1
+        assert seg2.ordinal == 2
+
+        # gap_before: True iff sequence is not exactly previous + 1; first is False
+        assert seg1.gap_before is False
+        assert seg2.gap_before is False
+        assert seg1.prev_sequence == 0
+        assert seg2.prev_sequence == 1
+
+        # start_name / end_name come from str(pathway.start_endpoint / end_endpoint)
+        assert seg1.start_name == str(linear_topology["a"])
+        assert seg1.end_name == str(linear_topology["b"])
+        assert seg2.start_name == str(linear_topology["b"])
+        assert seg2.end_name == str(linear_topology["c"])
+
+        # Direction inference: linear A -> B -> C means seg1 entry=A, exit=B
+        a_pk = linear_topology["a"].pk
+        b_pk = linear_topology["b"].pk
+        c_pk = linear_topology["c"].pk
+        assert seg1._entry_pk == a_pk
+        assert seg1._exit_pk == b_pk
+        assert seg2._entry_pk == b_pk
+        assert seg2._exit_pk == c_pk
+
+    def test_gap_before_set_when_sequence_jumps(self, linear_topology):
+        from dcim.models import Cable
+
+        cable = Cable.objects.create()
+        seg1 = CableSegment.objects.create(
+            cable=cable,
+            pathway=linear_topology["p1"],
+            sequence=1,
+        )
+        # Sequence jumps from 1 to 5 -- a gap
+        seg2 = CableSegment.objects.create(
+            cable=cable,
+            pathway=linear_topology["p2"],
+            sequence=5,
+        )
+        segments = [seg1, seg2]
+        _annotate_segments(segments)
+
+        assert seg1.gap_before is False
+        assert seg2.gap_before is True
+        # gap_start_pk / gap_end_pk wire the "Plan Route for this gap" button
+        assert seg2.gap_start_pk == seg1._exit_pk
+        assert seg2.gap_end_pk == seg2._entry_pk
+
+    def test_segment_without_pathway_has_no_endpoint_names(self, linear_topology):
+        from dcim.models import Cable
+
+        cable = Cable.objects.create()
+        # Segment with pathway=None (dangling / placeholder)
+        orphan = CableSegment.objects.create(cable=cable, pathway=None, sequence=1)
+        _annotate_segments([orphan])
+        assert orphan.start_name is None
+        assert orphan.end_name is None
+        assert orphan.ordinal == 1
+
+
+# ---------------------------------------------------------------------------
+# _start_node / _end_node
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def site(db):
+    from dcim.models import Site
+
+    return Site.objects.create(name="CR-site", slug="cr-site")
+
+
+@pytest.fixture
+def site_structure(site):
+    return Structure.objects.create(
+        name="CR-struct",
+        site=site,
+        location=Point(0, 0, srid=SRID),
+    )
+
+
+@pytest.mark.django_db
+class TestStartEndNode:
+    def test_returns_none_when_no_termination(self):
+        from dcim.models import Cable
+
+        mixin = CableRoutingMixin()
+        cable = Cable.objects.create(label="no-term")
+        assert mixin._start_node(cable) is None
+        assert mixin._end_node(cable) is None
+
+    def test_start_node_resolves_single_structure(self, site, site_structure):
+        mixin = CableRoutingMixin()
+        cable = build_cable_with_terminations(
+            label="CR-A",
+            site=site,
+            terminate_a=True,
+            terminate_b=False,
+        )
+        assert mixin._start_node(cable) == ("structure", site_structure.pk)
+        # B side has no termination -> None
+        assert mixin._end_node(cable) is None
+
+    def test_end_node_resolves_single_structure(self, site, site_structure):
+        mixin = CableRoutingMixin()
+        cable = build_cable_with_terminations(
+            label="CR-B",
+            site=site,
+            terminate_a=False,
+            terminate_b=True,
+        )
+        assert mixin._end_node(cable) == ("structure", site_structure.pk)
+        assert mixin._start_node(cable) is None
+
+    def test_start_node_picks_first_when_multiple_structures(self, site):
+        # Two structures in the same site: the mixin falls back to first()
+        s1 = Structure.objects.create(
+            name="CR-multi-1",
+            site=site,
+            location=Point(0, 0, srid=SRID),
+        )
+        Structure.objects.create(
+            name="CR-multi-2",
+            site=site,
+            location=Point(10, 10, srid=SRID),
+        )
+        mixin = CableRoutingMixin()
+        cable = build_cable_with_terminations(
+            label="CR-multi",
+            site=site,
+            terminate_a=True,
+            terminate_b=False,
+        )
+        result = mixin._start_node(cable)
+        # Either structure can win first(); both are valid graph nodes for the site
+        assert result == ("structure", s1.pk) or result[0] == "structure"
+
+
+# ---------------------------------------------------------------------------
+# _render_table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRenderTable:
+    @pytest.fixture(autouse=True)
+    def _no_routability_check(self, _disable_routability_signal):
+        yield
+
+    def test_renders_segments_with_labels(self, factory, admin_user, linear_topology):
+        from dcim.models import Cable
+
+        cable = Cable.objects.create(label="CR-render")
+        CableSegment.objects.create(
+            cable=cable,
+            pathway=linear_topology["p1"],
+            sequence=1,
+        )
+
+        request = factory.get(f"/pathways/cable/{cable.pk}/routing/table/")
+        request.user = admin_user
+
+        mixin = CableRoutingMixin()
+        response = mixin._render_table(request, cable)
+        assert response.status_code == 200
+        # The pathway label appears in the rendered table fragment
+        assert b"P1" in response.content
+
+    def test_renders_empty_state_when_no_segments(self, factory, admin_user):
+        from dcim.models import Cable
+
+        cable = Cable.objects.create(label="CR-empty")
+        request = factory.get(f"/pathways/cable/{cable.pk}/routing/table/")
+        request.user = admin_user
+
+        mixin = CableRoutingMixin()
+        response = mixin._render_table(request, cable)
+        assert response.status_code == 200
+        # The template renders an empty-state message rather than the table
+        assert b"No segments in this cable" in response.content

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,531 @@
+"""Tests for plugin-owned filterset custom methods.
+
+Covers the custom `filter_*` callbacks and the per-class `search()` overrides
+in `netbox_pathways.filters`. Framework filter behaviour (django-filter,
+ModelMultipleChoiceFilter, etc.) is intentionally not exercised here.
+"""
+
+import pytest
+from django.contrib.gis.geos import LineString, Point
+from django.db.models.signals import pre_save
+
+from netbox_pathways.filters import (
+    AerialSpanFilterSet,
+    CableSegmentFilterSet,
+    CircuitGeometryFilterSet,
+    ConduitBankFilterSet,
+    ConduitFilterSet,
+    ConduitJunctionFilterSet,
+    DirectBuriedFilterSet,
+    InnerductFilterSet,
+    PathwayFilterSet,
+    PathwayLocationFilterSet,
+    PlannedRouteFilterSet,
+    SiteGeometryFilterSet,
+    StructureFilterSet,
+)
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import (
+    AerialSpan,
+    CableSegment,
+    CircuitGeometry,
+    Conduit,
+    ConduitBank,
+    ConduitJunction,
+    DirectBuried,
+    Innerduct,
+    Pathway,
+    PathwayLocation,
+    PlannedRoute,
+    SiteGeometry,
+    Structure,
+)
+
+SRID = get_srid()
+
+
+@pytest.fixture
+def _disable_routability_signal():
+    """Disconnect the pre_save routability check so we can build orphan segments."""
+    from netbox_pathways.signals import enforce_cable_routability
+
+    pre_save.disconnect(enforce_cable_routability, sender=CableSegment)
+    yield
+    pre_save.connect(enforce_cable_routability, sender=CableSegment)
+
+
+@pytest.fixture
+def topology(db, _disable_routability_signal):
+    """Distinctive-named row of each model so each `search()` test can find it."""
+    from circuits.models import Circuit, CircuitType, Provider
+    from dcim.models import Cable, Location, Site
+    from tenancy.models import Tenant
+
+    tenant = Tenant.objects.create(name="distinct-tenant", slug="distinct-tenant")
+    site = Site.objects.create(name="distinct-site", slug="distinct-site")
+    location = Location.objects.create(name="distinct-loc", slug="distinct-loc", site=site)
+
+    s_start = Structure.objects.create(
+        name="connected-start",
+        location=Point(0, 0, srid=SRID),
+        tenant=tenant,
+        access_notes="access via gate B",
+    )
+    s_end = Structure.objects.create(
+        name="connected-end",
+        location=Point(100, 0, srid=SRID),
+    )
+    s_isolated = Structure.objects.create(
+        name="alone",
+        location=Point(500, 500, srid=SRID),
+    )
+
+    # Generic Pathway (no subclass) - used for searchable label tests.
+    pw = Pathway.objects.create(
+        label="searchable-pathway",
+        pathway_type="conduit",
+        path=LineString((0, 0), (100, 0), srid=SRID),
+        start_structure=s_start,
+        end_structure=s_end,
+        comments="pw-only-comment-text",
+    )
+
+    conduit = Conduit.objects.create(
+        label="searchable-conduit",
+        path=LineString((0, 10), (100, 10), srid=SRID),
+        start_structure=s_start,
+        end_structure=s_end,
+        comments="conduit-only-comment-text",
+    )
+
+    aerial = AerialSpan.objects.create(
+        label="searchable-aerial",
+        path=LineString((0, 20), (100, 20), srid=SRID),
+        start_structure=s_start,
+        end_structure=s_end,
+        comments="aerial-only-comment-text",
+    )
+
+    direct = DirectBuried.objects.create(
+        label="searchable-direct",
+        path=LineString((0, 30), (100, 30), srid=SRID),
+        start_structure=s_start,
+        end_structure=s_end,
+        comments="direct-only-comment-text",
+    )
+
+    bank = ConduitBank.objects.create(
+        label="searchable-bank",
+        path=LineString((0, 40), (100, 40), srid=SRID),
+        start_structure=s_start,
+        end_structure=s_end,
+        comments="bank-only-comment-text",
+    )
+
+    # Innerduct lives inside a parent Conduit.
+    innerduct = Innerduct.objects.create(
+        label="searchable-innerduct",
+        path=LineString((0, 10), (100, 10), srid=SRID),
+        parent_conduit=conduit,
+        size="32mm",
+        comments="innerduct-only-comment-text",
+    )
+
+    junction = ConduitJunction.objects.create(
+        label="searchable-junction",
+        trunk_conduit=conduit,
+        branch_conduit=conduit,
+        towards_structure=s_start,
+        position_on_trunk=0.5,
+        comments="junction-only-comment-text",
+    )
+
+    cable = Cable.objects.create(label="test-cable")
+    segment = CableSegment.objects.create(
+        cable=cable,
+        pathway=pw,
+        sequence=1,
+        comments="segment-only-comment-text",
+    )
+
+    waypoint = PathwayLocation.objects.create(
+        pathway=pw,
+        site=site,
+        location=location,
+        sequence=1,
+        comments="waypoint-only-comment-text",
+    )
+
+    site_geom = SiteGeometry.objects.create(site=site, structure=s_start)
+
+    provider = Provider.objects.create(name="search-provider", slug="search-provider")
+    ctype = CircuitType.objects.create(name="search-ctype", slug="search-ctype")
+    circuit = Circuit.objects.create(cid="SEARCHABLE-CID", provider=provider, type=ctype)
+    circuit_geom = CircuitGeometry.objects.create(
+        circuit=circuit,
+        path=LineString((0, 0), (1, 1), srid=SRID),
+        provider_reference="REF-SEARCHABLE",
+    )
+
+    planned = PlannedRoute.objects.create(
+        name="searchable-planned",
+        start_structure=s_start,
+        end_structure=s_end,
+        pathway_ids=[pw.pk],
+        comments="planned-only-comment-text",
+    )
+
+    return {
+        "tenant": tenant,
+        "site": site,
+        "location": location,
+        "s_start": s_start,
+        "s_end": s_end,
+        "s_isolated": s_isolated,
+        "pw": pw,
+        "conduit": conduit,
+        "aerial": aerial,
+        "direct": direct,
+        "bank": bank,
+        "innerduct": innerduct,
+        "junction": junction,
+        "cable": cable,
+        "segment": segment,
+        "waypoint": waypoint,
+        "site_geom": site_geom,
+        "circuit_geom": circuit_geom,
+        "planned": planned,
+    }
+
+
+# ---------------------------------------------------------------------------
+# StructureFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestStructureFilterOccupied:
+    def test_true_returns_structures_used_as_routed_endpoints(self, topology):
+        fs = StructureFilterSet({"occupied": True}, queryset=Structure.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert topology["s_start"].pk in pks
+        assert topology["s_end"].pk in pks
+        assert topology["s_isolated"].pk not in pks
+
+    def test_false_excludes_occupied_endpoints(self, topology):
+        fs = StructureFilterSet({"occupied": False}, queryset=Structure.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert topology["s_isolated"].pk in pks
+        assert topology["s_start"].pk not in pks
+        assert topology["s_end"].pk not in pks
+
+
+@pytest.mark.django_db
+class TestStructureFilterHasPathways:
+    def test_true_returns_only_pathway_endpoints(self, topology):
+        fs = StructureFilterSet({"has_pathways": True}, queryset=Structure.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        # s_start/s_end terminate several pathways; s_isolated terminates none.
+        assert topology["s_start"].pk in pks
+        assert topology["s_end"].pk in pks
+        assert topology["s_isolated"].pk not in pks
+
+    def test_false_returns_only_structures_without_pathways(self, topology):
+        fs = StructureFilterSet({"has_pathways": False}, queryset=Structure.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["s_isolated"].pk}
+
+
+@pytest.mark.django_db
+class TestStructureSearch:
+    def test_search_by_name_substring(self, topology):
+        fs = StructureFilterSet({"q": "connected"}, queryset=Structure.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["s_start"].pk, topology["s_end"].pk}
+
+    def test_search_by_tenant_name_substring(self, topology):
+        fs = StructureFilterSet({"q": "distinct-tenant"}, queryset=Structure.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["s_start"].pk}
+
+    def test_search_by_access_notes_substring(self, topology):
+        fs = StructureFilterSet({"q": "gate B"}, queryset=Structure.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["s_start"].pk}
+
+    def test_search_whitespace_only_returns_full_queryset(self, topology):
+        fs = StructureFilterSet({"q": "   "}, queryset=Structure.objects.all())
+        assert fs.qs.count() == Structure.objects.count()
+
+
+# ---------------------------------------------------------------------------
+# PathwayFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPathwayFilterOccupied:
+    def test_true_returns_only_pathways_with_cable_segments(self, topology):
+        fs = PathwayFilterSet({"occupied": True}, queryset=Pathway.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert topology["pw"].pk in pks
+        # Other pathways have no CableSegment rows.
+        assert topology["conduit"].pk not in pks
+        assert topology["aerial"].pk not in pks
+
+    def test_false_excludes_pathways_with_cable_segments(self, topology):
+        fs = PathwayFilterSet({"occupied": False}, queryset=Pathway.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert topology["pw"].pk not in pks
+        assert topology["conduit"].pk in pks
+
+
+@pytest.mark.django_db
+class TestPathwayFilterStructure:
+    def test_returns_pathways_with_structure_at_either_end(self, topology):
+        # Map queryset excludes innerducts; we expect the regular pathways but
+        # not the innerduct (and not bank-member conduits, but none exist here).
+        fs = PathwayFilterSet(
+            {"structure_id": [topology["s_start"].pk]},
+            queryset=Pathway.objects.all(),
+        )
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert topology["pw"].pk in pks
+        assert topology["conduit"].pk in pks
+        assert topology["innerduct"].pk not in pks
+
+    def test_empty_value_returns_queryset_unchanged(self, topology):
+        # An empty ModelMultipleChoiceFilter value short-circuits to queryset.
+        all_pks = set(Pathway.objects.values_list("pk", flat=True))
+        fs = PathwayFilterSet({}, queryset=Pathway.objects.all())
+        assert set(fs.qs.values_list("pk", flat=True)) == all_pks
+
+
+@pytest.mark.django_db
+class TestPathwaySearch:
+    def test_search_by_label_substring(self, topology):
+        fs = PathwayFilterSet({"q": "searchable-pathway"}, queryset=Pathway.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert topology["pw"].pk in pks
+        assert topology["conduit"].pk not in pks
+
+    def test_search_by_comments_substring(self, topology):
+        fs = PathwayFilterSet({"q": "pw-only-comment-text"}, queryset=Pathway.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["pw"].pk}
+
+    def test_search_whitespace_only_returns_full_queryset(self, topology):
+        fs = PathwayFilterSet({"q": "  "}, queryset=Pathway.objects.all())
+        assert fs.qs.count() == Pathway.objects.count()
+
+
+# ---------------------------------------------------------------------------
+# ConduitFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestConduitSearch:
+    def test_search_by_label_substring(self, topology):
+        fs = ConduitFilterSet({"q": "searchable-conduit"}, queryset=Conduit.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["conduit"].pk}
+
+    def test_search_by_comments_substring(self, topology):
+        fs = ConduitFilterSet({"q": "conduit-only-comment-text"}, queryset=Conduit.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["conduit"].pk}
+
+    def test_search_whitespace_only_returns_full_queryset(self, topology):
+        fs = ConduitFilterSet({"q": "   "}, queryset=Conduit.objects.all())
+        assert fs.qs.count() == Conduit.objects.count()
+
+
+# ---------------------------------------------------------------------------
+# AerialSpanFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAerialSpanSearch:
+    def test_search_by_label_substring(self, topology):
+        fs = AerialSpanFilterSet({"q": "searchable-aerial"}, queryset=AerialSpan.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["aerial"].pk}
+
+    def test_search_by_comments_substring(self, topology):
+        fs = AerialSpanFilterSet({"q": "aerial-only-comment-text"}, queryset=AerialSpan.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["aerial"].pk}
+
+
+# ---------------------------------------------------------------------------
+# DirectBuriedFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDirectBuriedSearch:
+    def test_search_by_label_substring(self, topology):
+        fs = DirectBuriedFilterSet({"q": "searchable-direct"}, queryset=DirectBuried.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["direct"].pk}
+
+    def test_search_by_comments_substring(self, topology):
+        fs = DirectBuriedFilterSet({"q": "direct-only-comment-text"}, queryset=DirectBuried.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["direct"].pk}
+
+
+# ---------------------------------------------------------------------------
+# InnerductFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestInnerductSearch:
+    def test_search_by_label_substring(self, topology):
+        fs = InnerductFilterSet({"q": "searchable-innerduct"}, queryset=Innerduct.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["innerduct"].pk}
+
+    def test_search_by_comments_substring(self, topology):
+        fs = InnerductFilterSet(
+            {"q": "innerduct-only-comment-text"},
+            queryset=Innerduct.objects.all(),
+        )
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["innerduct"].pk}
+
+
+# ---------------------------------------------------------------------------
+# ConduitBankFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestConduitBankSearch:
+    def test_search_by_label_substring(self, topology):
+        fs = ConduitBankFilterSet({"q": "searchable-bank"}, queryset=ConduitBank.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["bank"].pk}
+
+    def test_search_by_comments_substring(self, topology):
+        fs = ConduitBankFilterSet(
+            {"q": "bank-only-comment-text"},
+            queryset=ConduitBank.objects.all(),
+        )
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["bank"].pk}
+
+
+# ---------------------------------------------------------------------------
+# ConduitJunctionFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestConduitJunctionSearch:
+    def test_search_by_label_substring(self, topology):
+        fs = ConduitJunctionFilterSet(
+            {"q": "searchable-junction"},
+            queryset=ConduitJunction.objects.all(),
+        )
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["junction"].pk}
+
+    def test_search_by_comments_substring(self, topology):
+        fs = ConduitJunctionFilterSet(
+            {"q": "junction-only-comment-text"},
+            queryset=ConduitJunction.objects.all(),
+        )
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["junction"].pk}
+
+
+# ---------------------------------------------------------------------------
+# CableSegmentFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCableSegmentSearch:
+    def test_search_by_comments_substring(self, topology):
+        fs = CableSegmentFilterSet(
+            {"q": "segment-only-comment-text"},
+            queryset=CableSegment.objects.all(),
+        )
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["segment"].pk}
+
+    def test_search_whitespace_only_returns_full_queryset(self, topology):
+        fs = CableSegmentFilterSet({"q": "   "}, queryset=CableSegment.objects.all())
+        assert fs.qs.count() == CableSegment.objects.count()
+
+
+# ---------------------------------------------------------------------------
+# PathwayLocationFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPathwayLocationSearch:
+    def test_search_by_comments_substring(self, topology):
+        fs = PathwayLocationFilterSet(
+            {"q": "waypoint-only-comment-text"},
+            queryset=PathwayLocation.objects.all(),
+        )
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["waypoint"].pk}
+
+
+# ---------------------------------------------------------------------------
+# SiteGeometryFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestSiteGeometrySearch:
+    def test_search_by_site_name_substring(self, topology):
+        fs = SiteGeometryFilterSet({"q": "distinct-site"}, queryset=SiteGeometry.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["site_geom"].pk}
+
+
+# ---------------------------------------------------------------------------
+# CircuitGeometryFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCircuitGeometrySearch:
+    def test_search_by_circuit_cid_substring(self, topology):
+        fs = CircuitGeometryFilterSet({"q": "SEARCHABLE-CID"}, queryset=CircuitGeometry.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["circuit_geom"].pk}
+
+    def test_search_by_provider_reference_substring(self, topology):
+        fs = CircuitGeometryFilterSet({"q": "REF-SEARCHABLE"}, queryset=CircuitGeometry.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["circuit_geom"].pk}
+
+
+# ---------------------------------------------------------------------------
+# PlannedRouteFilterSet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPlannedRouteSearch:
+    def test_search_by_name_substring(self, topology):
+        fs = PlannedRouteFilterSet({"q": "searchable-planned"}, queryset=PlannedRoute.objects.all())
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["planned"].pk}
+
+    def test_search_by_comments_substring(self, topology):
+        fs = PlannedRouteFilterSet(
+            {"q": "planned-only-comment-text"},
+            queryset=PlannedRoute.objects.all(),
+        )
+        pks = set(fs.qs.values_list("pk", flat=True))
+        assert pks == {topology["planned"].pk}

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,8 +2,21 @@ import pytest
 from django.contrib.gis.geos import LineString, Point
 
 from netbox_pathways.geo import get_srid
-from netbox_pathways.graph import PathwayGraph
-from netbox_pathways.models import Conduit, Structure
+from netbox_pathways.graph import (
+    PathwayGraph,
+    batch_resolve_nodes,
+    connected_pathways_db,
+    node_to_geo,
+    node_to_label,
+    trace_cable,
+)
+from netbox_pathways.models import (
+    CableSegment,
+    Conduit,
+    ConduitJunction,
+    Pathway,
+    Structure,
+)
 
 
 @pytest.mark.django_db
@@ -96,3 +109,563 @@ class TestPathwayGraph:
         dest_nodes = {c["destination"] for c in connected}
         assert ("structure", structures[1].pk) in dest_nodes
         assert ("structure", structures[3].pk) in dest_nodes
+
+    def test_connected_pathways_unknown_node(self, pathways):
+        """Unknown nodes return an empty list, not an error (line 307)."""
+        graph = PathwayGraph.build()
+        assert graph.connected_pathways(("structure", 99999999)) == []
+
+    def test_neighbors_bfs_expands_within_max_hops(self, structures, pathways):
+        """BFS returns reachable nodes with hops and accumulated cost (lines 327-357)."""
+        graph = PathwayGraph.build()
+        start = ("structure", structures[0].pk)
+        # max_hops=1 -> only direct neighbors
+        one_hop = graph.neighbors(start, max_hops=1)
+        # S0 connects directly to S1 and S3
+        assert ("structure", structures[1].pk) in one_hop
+        assert ("structure", structures[3].pk) in one_hop
+        # S2 is two hops away, must not appear at max_hops=1
+        assert ("structure", structures[2].pk) not in one_hop
+        # Each result is (dist, hops, [pathway_ids])
+        dist, hops, ids = one_hop[("structure", structures[1].pk)]
+        assert hops == 1
+        assert dist == 10
+        assert len(ids) == 1
+
+    def test_neighbors_bfs_two_hops(self, structures, pathways):
+        """BFS at max_hops=2 reaches S2 via S1."""
+        graph = PathwayGraph.build()
+        start = ("structure", structures[0].pk)
+        two_hop = graph.neighbors(start, max_hops=2)
+        # S2 reached via S0->S1->S2 (10 + 20 = 30) at 2 hops
+        assert ("structure", structures[2].pk) in two_hop
+        dist, hops, ids = two_hop[("structure", structures[2].pk)]
+        assert hops == 2
+        assert dist == 30
+        assert len(ids) == 2
+
+    def test_neighbors_unknown_node(self, pathways):
+        """neighbors() returns empty dict when start_node not in graph."""
+        graph = PathwayGraph.build()
+        assert graph.neighbors(("structure", 99999999)) == {}
+
+    def test_all_routes_unknown_node(self, structures, pathways):
+        """all_routes returns [] when either endpoint not in graph (line 286)."""
+        graph = PathwayGraph.build()
+        start = ("structure", structures[0].pk)
+        assert graph.all_routes(start, ("structure", 99999999)) == []
+        assert graph.all_routes(("structure", 99999999), start) == []
+
+    def test_all_routes_respects_max_routes(self, structures, pathways):
+        """max_routes caps the number of routes returned (line 299)."""
+        graph = PathwayGraph.build()
+        start = ("structure", structures[0].pk)
+        end = ("structure", structures[3].pk)
+        # Two simple paths exist; cap at 1
+        routes = graph.all_routes(start, end, max_routes=1)
+        assert len(routes) == 1
+
+    def test_astar_no_path_returns_none(self, srid):
+        """A* returns None when no path exists between nodes (lines 279-280)."""
+        s1 = Structure.objects.create(name="AS-1", location=Point(0, 0, srid=srid))
+        s2 = Structure.objects.create(name="AS-2", location=Point(1, 1, srid=srid))
+        # Pathways exist for s1 only so both nodes are in the graph but disconnected.
+        Conduit.objects.create(
+            label="AS-self-loop",
+            start_structure=s1,
+            end_structure=s1,
+            path=LineString((0, 0), (0, 0), srid=srid),
+            length=1,
+        )
+        graph = PathwayGraph.build()
+        # s2 not in graph -> astar handles NodeNotFound branch
+        assert graph.astar_path(("structure", s1.pk), ("structure", s2.pk)) is None
+
+    def test_shortest_path_returns_none_on_unknown_node(self, structures, pathways):
+        """shortest_path returns None when an endpoint is not in the graph (NodeNotFound)."""
+        graph = PathwayGraph.build()
+        start = ("structure", structures[0].pk)
+        assert graph.shortest_path(start, ("structure", 99999999)) is None
+
+    def test_haversine_returns_zero_when_geo_missing(self, structures, pathways):
+        """A* heuristic returns 0 when either node lacks geo metadata (line 374).
+
+        build_topology() (vs build()) skips geo annotations entirely, so every
+        node has geo=None -- triggering the heuristic's no-geo short-circuit.
+        """
+        topo = PathwayGraph.build_topology()
+        start = ("structure", structures[0].pk)
+        end = ("structure", structures[3].pk)
+        assert topo._haversine_heuristic(start, end) == 0
+
+    def test_shortest_path_nodes_returns_node_list(self, structures, pathways):
+        """shortest_path_nodes returns (cost, pathway_ids, nodes) tuple."""
+        graph = PathwayGraph.build()
+        start = ("structure", structures[0].pk)
+        end = ("structure", structures[3].pk)
+        result = graph.shortest_path_nodes(start, end)
+        assert result is not None
+        cost, pathway_ids, nodes = result
+        assert cost == 35
+        # The node list starts and ends at the requested endpoints
+        assert nodes[0] == start
+        assert nodes[-1] == end
+
+
+# ---------------------------------------------------------------------------
+# build_topology branches: location endpoints, junctions, start==end skip, cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestBuildTopology:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        PathwayGraph._topo_cache = None
+        yield
+        PathwayGraph._topo_cache = None
+
+    @pytest.fixture
+    def srid(self):
+        return get_srid()
+
+    def test_build_endpoint_nodes_location_and_junction_branches(self, srid):
+        """_endpoint_nodes uses location/junction fallbacks (lines 24-30, 36-38).
+
+        Reached through build() (not build_topology), which calls _endpoint_nodes
+        on annotated Pathway instances.
+        """
+        from dcim.models import Location, Site
+
+        site = Site.objects.create(name="ep-site", slug="ep-site")
+        loc_a = Location.objects.create(name="ep-loc-a", slug="ep-loc-a", site=site)
+        loc_b = Location.objects.create(name="ep-loc-b", slug="ep-loc-b", site=site)
+        # Pathway with location-only endpoints exercises start_location_id /
+        # end_location_id branches in _endpoint_nodes.
+        Pathway.objects.create(
+            label="ep-loc-only",
+            pathway_type="conduit",
+            path=LineString((0, 0), (1, 1), srid=srid),
+            start_location=loc_a,
+            end_location=loc_b,
+        )
+
+        # Conduit with a junction endpoint exercises the _start_junction_id /
+        # _end_junction_id annotation branches.
+        s0 = Structure.objects.create(name="ep-s0", location=Point(0, 0, srid=srid))
+        s1 = Structure.objects.create(name="ep-s1", location=Point(0.02, 0.02, srid=srid))
+        s2 = Structure.objects.create(name="ep-s2", location=Point(0.03, 0.01, srid=srid))
+        trunk = Conduit.objects.create(
+            label="ep-trunk",
+            start_structure=s0,
+            end_structure=s1,
+            path=LineString((0, 0), (0.02, 0.02), srid=srid),
+            length=100,
+        )
+        stub = Conduit.objects.create(
+            label="ep-stub",
+            start_structure=s2,
+            end_structure=s2,
+            path=LineString((0.03, 0.01), (0.03, 0.01), srid=srid),
+            length=1,
+        )
+        junction = ConduitJunction.objects.create(
+            label="ep-J",
+            trunk_conduit=trunk,
+            branch_conduit=stub,
+            towards_structure=s1,
+            position_on_trunk=0.5,
+        )
+        Conduit.objects.create(
+            label="ep-branch",
+            start_junction=junction,
+            end_structure=s2,
+            path=LineString((0.01, 0.01), (0.03, 0.01), srid=srid),
+            length=20,
+        )
+        # Second branch with junction as the END endpoint exercises the
+        # `end_junc` branch in _endpoint_nodes (line 38).
+        Conduit.objects.create(
+            label="ep-branch-end",
+            start_structure=s2,
+            end_junction=junction,
+            path=LineString((0.03, 0.01), (0.01, 0.01), srid=srid),
+            length=21,
+        )
+
+        graph = PathwayGraph.build()
+        # Location nodes wired in via _endpoint_nodes location branches
+        assert ("location", loc_a.pk) in graph.graph
+        assert ("location", loc_b.pk) in graph.graph
+        # Junction node wired in via _endpoint_nodes junction branches
+        assert ("junction", junction.pk) in graph.graph
+
+    def test_build_filters_by_site_id(self, srid):
+        """_build_base applies a Q(start_structure__site_id|end_structure__site_id) filter (line 194)."""
+        from dcim.models import Site
+
+        site_a = Site.objects.create(name="bf-site-a", slug="bf-site-a")
+        site_b = Site.objects.create(name="bf-site-b", slug="bf-site-b")
+        a1 = Structure.objects.create(name="bf-a1", location=Point(0, 0, srid=srid), site=site_a)
+        a2 = Structure.objects.create(name="bf-a2", location=Point(0.01, 0.01, srid=srid), site=site_a)
+        b1 = Structure.objects.create(name="bf-b1", location=Point(1, 1, srid=srid), site=site_b)
+        b2 = Structure.objects.create(name="bf-b2", location=Point(1.01, 1.01, srid=srid), site=site_b)
+        Pathway.objects.create(
+            label="bf-a-pw",
+            pathway_type="conduit",
+            path=LineString((0, 0), (0.01, 0.01), srid=srid),
+            start_structure=a1,
+            end_structure=a2,
+        )
+        Pathway.objects.create(
+            label="bf-b-pw",
+            pathway_type="conduit",
+            path=LineString((1, 1), (1.01, 1.01), srid=srid),
+            start_structure=b1,
+            end_structure=b2,
+        )
+        graph = PathwayGraph.build(site_id=site_a.pk)
+        # Only site_a's pathway nodes should appear
+        assert ("structure", a1.pk) in graph.graph
+        assert ("structure", a2.pk) in graph.graph
+        assert ("structure", b1.pk) not in graph.graph
+        assert ("structure", b2.pk) not in graph.graph
+
+    def test_build_topology_location_endpoints(self, srid):
+        """Pathways with start_location / end_location create location nodes (lines 113-118)."""
+        from dcim.models import Location, Site
+
+        site = Site.objects.create(name="topo-site", slug="topo-site")
+        loc_a = Location.objects.create(name="topo-loc-a", slug="topo-loc-a", site=site)
+        loc_b = Location.objects.create(name="topo-loc-b", slug="topo-loc-b", site=site)
+        # Pathway with location-only endpoints (no structures)
+        Pathway.objects.create(
+            label="loc-only",
+            pathway_type="conduit",
+            path=LineString((0, 0), (1, 1), srid=srid),
+            start_location=loc_a,
+            end_location=loc_b,
+        )
+        topo = PathwayGraph.build_topology()
+        assert ("location", loc_a.pk) in topo.graph
+        assert ("location", loc_b.pk) in topo.graph
+        assert topo.graph.has_edge(("location", loc_a.pk), ("location", loc_b.pk))
+
+    def test_build_topology_skips_self_loop(self, srid):
+        """A pathway whose start and end resolve to the same node is skipped (line 121)."""
+        s = Structure.objects.create(name="self-loop", location=Point(0, 0, srid=srid))
+        Pathway.objects.create(
+            label="self",
+            pathway_type="conduit",
+            path=LineString((0, 0), (0, 0), srid=srid),
+            start_structure=s,
+            end_structure=s,
+        )
+        topo = PathwayGraph.build_topology()
+        # The self-loop pathway must not produce any edge for this node
+        if ("structure", s.pk) in topo.graph:
+            assert topo.graph.degree(("structure", s.pk)) == 0
+
+    def test_build_topology_cache_returns_same_instance(self, srid):
+        """A second call within TTL returns the cached instance (line 87)."""
+        Structure.objects.create(name="cache-s", location=Point(0, 0, srid=srid))
+        first = PathwayGraph.build_topology()
+        second = PathwayGraph.build_topology()
+        assert first is second
+
+    def test_build_topology_with_qs_bypasses_cache(self, srid):
+        """Passing pathway_qs bypasses the cache entirely (use_cache=False branch)."""
+        s1 = Structure.objects.create(name="qs-s1", location=Point(0, 0, srid=srid))
+        s2 = Structure.objects.create(name="qs-s2", location=Point(0.01, 0.01, srid=srid))
+        pw = Pathway.objects.create(
+            label="qs-pw",
+            pathway_type="conduit",
+            path=LineString((0, 0), (0.01, 0.01), srid=srid),
+            start_structure=s1,
+            end_structure=s2,
+            length=42,
+        )
+        # Provide a queryset filtered to only this pathway
+        qs = Pathway.objects.filter(pk=pw.pk)
+        topo_filtered = PathwayGraph.build_topology(pathway_qs=qs)
+        # Filtered topology has just this one edge
+        assert topo_filtered.graph.number_of_edges() == 1
+        # And no cache was populated by this call
+        assert PathwayGraph._topo_cache is None
+
+    def test_build_topology_junction_edges(self, srid):
+        """Conduits with junction endpoints add junction-keyed edges (lines 144-149).
+
+        Topology: S0 --trunk-- S1, with a junction J on the trunk.
+        A branch conduit attaches to J via start_junction, ending at S2.
+        After build_topology, ('junction', J.pk) is a node and the branch
+        edge runs from the junction to ('structure', S2).
+        """
+        s0 = Structure.objects.create(name="J-s0", location=Point(0, 0, srid=srid))
+        s1 = Structure.objects.create(name="J-s1", location=Point(0.02, 0.02, srid=srid))
+        s2 = Structure.objects.create(name="J-s2", location=Point(0.03, 0.01, srid=srid))
+        trunk = Conduit.objects.create(
+            label="J-trunk",
+            start_structure=s0,
+            end_structure=s1,
+            path=LineString((0, 0), (0.02, 0.02), srid=srid),
+            length=100,
+        )
+        branch = Conduit.objects.create(
+            label="J-branch-stub",
+            start_structure=s2,
+            end_structure=s2,  # placeholder; we'll repoint to a junction below
+            path=LineString((0.03, 0.01), (0.03, 0.01), srid=srid),
+            length=1,
+        )
+        junction = ConduitJunction.objects.create(
+            label="J",
+            trunk_conduit=trunk,
+            branch_conduit=branch,
+            towards_structure=s1,
+            position_on_trunk=0.5,
+        )
+        # Now create the real branch conduit from junction -> s2
+        branch_real = Conduit.objects.create(
+            label="J-branch",
+            start_structure=None,
+            start_junction=junction,
+            end_structure=s2,
+            path=LineString((0.01, 0.01), (0.03, 0.01), srid=srid),
+            length=20,
+        )
+
+        topo = PathwayGraph.build_topology()
+        assert ("junction", junction.pk) in topo.graph
+        # Junction-to-structure edge exists with our branch_real's pk
+        edge = topo.graph.edges[("junction", junction.pk), ("structure", s2.pk)]
+        assert edge["pathway_id"] == branch_real.pathway_ptr_id
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestConnectedPathwaysDb:
+    @pytest.fixture
+    def srid(self):
+        return get_srid()
+
+    def test_structure_node(self, srid):
+        """connected_pathways_db filters by structure on either end (line 392)."""
+        s1 = Structure.objects.create(name="cpd-s1", location=Point(0, 0, srid=srid))
+        s2 = Structure.objects.create(name="cpd-s2", location=Point(0.01, 0.01, srid=srid))
+        s3 = Structure.objects.create(name="cpd-s3", location=Point(0.02, 0.02, srid=srid))
+        pw_in = Pathway.objects.create(
+            label="cpd-in",
+            pathway_type="conduit",
+            path=LineString((0, 0), (0.01, 0.01), srid=srid),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        pw_out = Pathway.objects.create(
+            label="cpd-out",
+            pathway_type="conduit",
+            path=LineString((0.01, 0.01), (0.02, 0.02), srid=srid),
+            start_structure=s2,
+            end_structure=s3,
+        )
+        result = list(connected_pathways_db(("structure", s2.pk)))
+        pks = {p.pk for p in result}
+        assert pw_in.pk in pks
+        assert pw_out.pk in pks
+
+    def test_location_node(self, srid):
+        """connected_pathways_db handles location nodes (line 394)."""
+        from dcim.models import Location, Site
+
+        site = Site.objects.create(name="cpd-site", slug="cpd-site")
+        loc = Location.objects.create(name="cpd-loc", slug="cpd-loc", site=site)
+        s = Structure.objects.create(name="cpd-loc-s", location=Point(0, 0, srid=srid))
+        pw = Pathway.objects.create(
+            label="cpd-loc-pw",
+            pathway_type="conduit",
+            path=LineString((0, 0), (0.01, 0.01), srid=srid),
+            start_structure=s,
+            end_location=loc,
+        )
+        result = list(connected_pathways_db(("location", loc.pk)))
+        assert pw in result
+
+    def test_junction_node(self, srid):
+        """connected_pathways_db handles junction nodes (line 396)."""
+        s0 = Structure.objects.create(name="cpd-j0", location=Point(0, 0, srid=srid))
+        s1 = Structure.objects.create(name="cpd-j1", location=Point(0.02, 0.02, srid=srid))
+        s2 = Structure.objects.create(name="cpd-j2", location=Point(0.03, 0.01, srid=srid))
+        trunk = Conduit.objects.create(
+            label="cpd-trunk",
+            start_structure=s0,
+            end_structure=s1,
+            path=LineString((0, 0), (0.02, 0.02), srid=srid),
+            length=50,
+        )
+        stub = Conduit.objects.create(
+            label="cpd-stub",
+            start_structure=s2,
+            end_structure=s2,
+            path=LineString((0.03, 0.01), (0.03, 0.01), srid=srid),
+            length=1,
+        )
+        junction = ConduitJunction.objects.create(
+            label="cpd-J",
+            trunk_conduit=trunk,
+            branch_conduit=stub,
+            towards_structure=s1,
+            position_on_trunk=0.5,
+        )
+        branch = Conduit.objects.create(
+            label="cpd-branch",
+            start_junction=junction,
+            end_structure=s2,
+            path=LineString((0.01, 0.01), (0.03, 0.01), srid=srid),
+            length=20,
+        )
+        result = list(connected_pathways_db(("junction", junction.pk)))
+        # Branch attaches to the junction directly
+        assert any(p.pk == branch.pathway_ptr_id for p in result)
+
+    def test_unknown_node_type_returns_empty(self):
+        """Unknown node kind returns an empty queryset (line 398)."""
+        result = connected_pathways_db(("bogus", 1))
+        assert list(result) == []
+
+
+@pytest.mark.django_db
+class TestTraceCable:
+    @pytest.fixture
+    def srid(self):
+        return get_srid()
+
+    @pytest.fixture(autouse=True)
+    def _disable_routability_signal(self):
+        from django.db.models.signals import pre_save
+
+        from netbox_pathways.signals import enforce_cable_routability
+
+        pre_save.disconnect(enforce_cable_routability, sender=CableSegment)
+        yield
+        pre_save.connect(enforce_cable_routability, sender=CableSegment)
+
+    def test_returns_segments_in_sequence(self, srid):
+        """trace_cable orders segments by sequence and exposes pathway metadata."""
+        from dcim.models import Cable
+
+        s1 = Structure.objects.create(name="tc-s1", location=Point(0, 0, srid=srid))
+        s2 = Structure.objects.create(name="tc-s2", location=Point(0.01, 0.01, srid=srid))
+        s3 = Structure.objects.create(name="tc-s3", location=Point(0.02, 0.02, srid=srid))
+        pw1 = Pathway.objects.create(
+            label="tc-pw1",
+            pathway_type="conduit",
+            path=LineString((0, 0), (0.01, 0.01), srid=srid),
+            start_structure=s1,
+            end_structure=s2,
+            length=10,
+        )
+        pw2 = Pathway.objects.create(
+            label="tc-pw2",
+            pathway_type="conduit",
+            path=LineString((0.01, 0.01), (0.02, 0.02), srid=srid),
+            start_structure=s2,
+            end_structure=s3,
+            length=20,
+        )
+        cable = Cable.objects.create(label="tc-cable")
+        # Create segments out of sequence to confirm ordering
+        CableSegment.objects.create(cable=cable, pathway=pw2, sequence=2)
+        CableSegment.objects.create(cable=cable, pathway=pw1, sequence=1)
+
+        result = trace_cable(cable.pk)
+        assert [r["pathway_id"] for r in result] == [pw1.pk, pw2.pk]
+        # Each entry exposes coords (LineString -> list of coord pairs)
+        assert result[0]["pathway_type"] == "conduit"
+        assert result[0]["length"] == 10
+        assert len(result[0]["coords"]) == 2
+        # Endpoint names resolve via the pathway's start/end endpoints
+        assert result[0]["start_name"] == str(s1)
+        assert result[0]["end_name"] == str(s2)
+
+    def test_segment_without_pathway_yields_null_fields(self, srid):
+        """A segment whose pathway was deleted (SET_NULL) still appears with null fields."""
+        from dcim.models import Cable
+
+        s1 = Structure.objects.create(name="tc-null-s1", location=Point(0, 0, srid=srid))
+        s2 = Structure.objects.create(name="tc-null-s2", location=Point(0.01, 0.01, srid=srid))
+        pw = Pathway.objects.create(
+            label="tc-null-pw",
+            pathway_type="conduit",
+            path=LineString((0, 0), (0.01, 0.01), srid=srid),
+            start_structure=s1,
+            end_structure=s2,
+            length=10,
+        )
+        cable = Cable.objects.create(label="tc-null-cable")
+        CableSegment.objects.create(cable=cable, pathway=pw, sequence=1)
+        pw.delete()  # SET_NULL on pathway FK
+
+        result = trace_cable(cable.pk)
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["pathway_id"] is None
+        assert entry["pathway_name"] is None
+        assert entry["coords"] == []
+        assert entry["start_name"] is None
+        assert entry["end_name"] is None
+
+
+@pytest.mark.django_db
+class TestBatchResolveNodes:
+    @pytest.fixture
+    def srid(self):
+        return get_srid()
+
+    def test_resolves_structure_label_and_geo(self, srid):
+        s = Structure.objects.create(name="brn-s", location=Point(1.5, 2.5, srid=srid))
+        resolved = batch_resolve_nodes([("structure", s.pk)])
+        entry = resolved[("structure", s.pk)]
+        assert entry["label"] == str(s)
+        assert entry["geo"] is not None  # (lat, lon)
+
+    def test_missing_structure_falls_back_to_placeholder_label(self):
+        resolved = batch_resolve_nodes([("structure", 9999999)])
+        assert resolved[("structure", 9999999)]["label"] == "Structure #9999999"
+        assert resolved[("structure", 9999999)]["geo"] is None
+
+    def test_resolves_location_label(self, srid):
+        from dcim.models import Location, Site
+
+        site = Site.objects.create(name="brn-site", slug="brn-site")
+        loc = Location.objects.create(name="brn-loc", slug="brn-loc", site=site)
+        resolved = batch_resolve_nodes([("location", loc.pk)])
+        entry = resolved[("location", loc.pk)]
+        assert entry["label"] == str(loc)
+        # Locations do not carry geo through this helper
+        assert entry["geo"] is None
+
+    def test_missing_location_falls_back_to_placeholder_label(self):
+        resolved = batch_resolve_nodes([("location", 9999999)])
+        assert resolved[("location", 9999999)]["label"] == "Location #9999999"
+
+    # NOTE: junction resolution via batch_resolve_nodes is not testable until the
+    # source bug in graph._batch_fetch_junctions is fixed -- it calls
+    # `.only("name", "trunk_conduit__name", ...)` but ConduitJunction and Pathway
+    # both use `label`, not `name`, so the query raises FieldDoesNotExist on eval.
+
+    def test_node_to_label_single_node_convenience(self, srid):
+        s = Structure.objects.create(name="ntl-s", location=Point(0, 0, srid=srid))
+        assert node_to_label(("structure", s.pk)) == str(s)
+
+    def test_node_to_geo_single_node_convenience(self, srid):
+        s = Structure.objects.create(name="ntg-s", location=Point(1, 2, srid=srid))
+        geo = node_to_geo(("structure", s.pk))
+        assert geo is not None
+        lat, lon = geo
+        # Sanity: WGS84 lat/lon range
+        assert -90 <= lat <= 90
+        assert -180 <= lon <= 180

--- a/tests/test_import_geodata.py
+++ b/tests/test_import_geodata.py
@@ -1,4 +1,12 @@
-from netbox_pathways.management.commands.import_geodata import _matches_null_value
+import datetime
+
+import pytest
+
+from netbox_pathways.management.commands.import_geodata import (
+    TRANSFORMS,
+    Command,
+    _matches_null_value,
+)
 
 
 class TestMatchesNullValue:
@@ -34,3 +42,193 @@ class TestMatchesNullValue:
         # None entries in the list should be ignored, not crash
         assert _matches_null_value(0, [None, 0]) is True
         assert _matches_null_value(1, [None]) is False
+
+
+class TestTransforms:
+    """Cover the TRANSFORMS lambdas used by _apply_field_spec and aggregate fields."""
+
+    def test_year_to_date_positive_year(self):
+        assert TRANSFORMS["year_to_date"]("1995") == datetime.date(1995, 1, 1)
+
+    def test_year_to_date_zero_returns_none(self):
+        # Zero is treated as "no data" so we get None.
+        assert TRANSFORMS["year_to_date"](0) is None
+
+    def test_year_to_date_none_returns_none(self):
+        assert TRANSFORMS["year_to_date"](None) is None
+
+    def test_to_int_string(self):
+        assert TRANSFORMS["to_int"]("42") == 42
+
+    def test_to_int_none(self):
+        assert TRANSFORMS["to_int"](None) is None
+
+    def test_to_float_string(self):
+        assert TRANSFORMS["to_float"]("3.14") == pytest.approx(3.14)
+
+    def test_to_float_none(self):
+        assert TRANSFORMS["to_float"](None) is None
+
+    def test_to_bool_string_one_is_true(self):
+        assert TRANSFORMS["to_bool"]("1") is True
+
+    def test_to_bool_string_zero_is_false(self):
+        assert TRANSFORMS["to_bool"]("0") is False
+
+    def test_to_bool_none_returns_false(self):
+        assert TRANSFORMS["to_bool"](None) is False
+
+    def test_to_str_coerces(self):
+        assert TRANSFORMS["to_str"](42) == "42"
+
+    def test_to_str_none_returns_empty_string(self):
+        assert TRANSFORMS["to_str"](None) == ""
+
+    def test_boolean_flag_truthy(self):
+        assert TRANSFORMS["boolean_flag"]("1") is True
+
+    def test_boolean_flag_none_is_false(self):
+        assert TRANSFORMS["boolean_flag"](None) is False
+
+
+class _FakeFeature:
+    """Minimal stand-in for an OGR Feature that supports .get(field)."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, key):
+        return self._data.get(key)
+
+
+class TestPassesFilters:
+    """Cover Command._passes_filters: per-field equality with stringified compare."""
+
+    def _cmd(self):
+        # Instantiate without invoking BaseCommand's heavy init plumbing for handle().
+        return Command()
+
+    def test_empty_filters_always_passes(self):
+        feature = _FakeFeature({"status": "ACTIVE"})
+        assert self._cmd()._passes_filters(feature, {}) is True
+
+    def test_all_filters_match(self):
+        feature = _FakeFeature({"status": "ACTIVE", "kind": "pole"})
+        assert self._cmd()._passes_filters(feature, {"status": "ACTIVE", "kind": "pole"}) is True
+
+    def test_single_mismatch_fails(self):
+        feature = _FakeFeature({"status": "ACTIVE"})
+        assert self._cmd()._passes_filters(feature, {"status": "RETIRED"}) is False
+
+    def test_string_int_comparison_uses_str_strip(self):
+        # Feature returns int 5, schema specifies string "5" -- should compare equal.
+        feature = _FakeFeature({"count": 5})
+        assert self._cmd()._passes_filters(feature, {"count": "5"}) is True
+
+    def test_whitespace_in_value_is_stripped(self):
+        feature = _FakeFeature({"status": "  ACTIVE  "})
+        assert self._cmd()._passes_filters(feature, {"status": "ACTIVE"}) is True
+
+
+class TestApplyFieldSpec:
+    """Cover Command._apply_field_spec pipeline: null -> regex -> map -> transform -> format."""
+
+    def _cmd(self):
+        return Command()
+
+    def test_non_dict_spec_returns_value_unchanged(self):
+        assert self._cmd()._apply_field_spec("anything", "not_a_dict") == "anything"
+
+    def test_null_values_short_circuits_to_none(self):
+        spec = {"null_values": [0, "N/A"], "transform": "to_int"}
+        # Even with a transform queued, null match returns None immediately.
+        assert self._cmd()._apply_field_spec("N/A", spec) is None
+
+    def test_regex_extracts_default_group(self):
+        spec = {"regex": r"^POLE-(\d+)$"}
+        assert self._cmd()._apply_field_spec("POLE-42", spec) == "42"
+
+    def test_regex_uses_explicit_group(self):
+        spec = {"regex": r"^(\w+)-(\d+)$", "regex_group": 2}
+        assert self._cmd()._apply_field_spec("POLE-42", spec) == "42"
+
+    def test_regex_no_match_returns_default(self):
+        spec = {"regex": r"^POLE-(\d+)$", "default": "unknown"}
+        assert self._cmd()._apply_field_spec("MANHOLE-7", spec) == "unknown"
+
+    def test_regex_no_match_no_default_returns_none(self):
+        spec = {"regex": r"^POLE-(\d+)$"}
+        assert self._cmd()._apply_field_spec("MANHOLE-7", spec) is None
+
+    def test_map_hit_returns_mapped_value(self):
+        spec = {"map": {"A": "active", "R": "retired"}}
+        assert self._cmd()._apply_field_spec("A", spec) == "active"
+
+    def test_map_miss_returns_default(self):
+        spec = {"map": {"A": "active"}, "default": "planned"}
+        assert self._cmd()._apply_field_spec("ZZ", spec) == "planned"
+
+    def test_map_strips_whitespace_on_key(self):
+        spec = {"map": {"A": "active"}}
+        assert self._cmd()._apply_field_spec("  A  ", spec) == "active"
+
+    def test_transform_invokes_lambda(self):
+        spec = {"transform": "to_int"}
+        assert self._cmd()._apply_field_spec("123", spec) == 123
+
+    def test_transform_unknown_raises(self):
+        from django.core.management.base import CommandError
+
+        spec = {"transform": "does_not_exist"}
+        with pytest.raises(CommandError):
+            self._cmd()._apply_field_spec("x", spec)
+
+    def test_format_template_applies(self):
+        spec = {"format": "PREFIX-{value}"}
+        assert self._cmd()._apply_field_spec("42", spec) == "PREFIX-42"
+
+    def test_format_falls_back_to_str_on_error(self):
+        # KeyError path: template references missing placeholder.
+        spec = {"format": "{missing}"}
+        assert self._cmd()._apply_field_spec(99, spec) == "99"
+
+    def test_regex_then_map_chain(self):
+        # The pipeline runs in order; regex output feeds map lookup.
+        spec = {
+            "regex": r"^(\w+)-",
+            "map": {"POLE": "structure", "MH": "manhole"},
+        }
+        assert self._cmd()._apply_field_spec("POLE-42", spec) == "structure"
+
+    def test_regex_then_transform_chain(self):
+        spec = {"regex": r"(\d+)", "transform": "to_int"}
+        assert self._cmd()._apply_field_spec("count=37", spec) == 37
+
+
+class TestLoadSchema:
+    """Cover Command._load_schema: YAML file loading with error wrapping."""
+
+    def _cmd(self):
+        return Command()
+
+    def test_loads_valid_yaml(self, tmp_path):
+        schema_path = tmp_path / "schema.yaml"
+        schema_path.write_text("model: structure\ngeometry_field: location\n")
+        loaded = self._cmd()._load_schema(str(schema_path))
+        assert loaded == {"model": "structure", "geometry_field": "location"}
+
+    def test_missing_file_raises_command_error(self, tmp_path):
+        from django.core.management.base import CommandError
+
+        missing = tmp_path / "does_not_exist.yaml"
+        with pytest.raises(CommandError, match="Schema file not found"):
+            self._cmd()._load_schema(str(missing))
+
+    def test_invalid_yaml_raises_command_error(self, tmp_path):
+        from django.core.management.base import CommandError
+
+        schema_path = tmp_path / "broken.yaml"
+        # Unbalanced bracket: PyYAML's parser raises YAMLError on this.
+        schema_path.write_text("model: [unterminated\n")
+        with pytest.raises(CommandError, match="Invalid YAML"):
+            self._cmd()._load_schema(str(schema_path))

--- a/tests/test_pathway_endpoint_form_mixin.py
+++ b/tests/test_pathway_endpoint_form_mixin.py
@@ -1,0 +1,96 @@
+"""Tests for PathwayEndpointFormMixin.clean -- form-side auto-path generation."""
+
+import pytest
+from django.contrib.gis.geos import LineString, Point, Polygon
+
+from netbox_pathways.forms import ConduitForm, InnerductForm
+from netbox_pathways.geo import get_srid, to_leaflet
+from netbox_pathways.models import Conduit, Structure
+
+SRID = get_srid()
+
+
+def _make_structure(name, geom):
+    return Structure.objects.create(name=name, location=geom)
+
+
+@pytest.mark.django_db
+class TestPathwayEndpointFormMixinClean:
+    def test_provided_path_is_kept(self):
+        """If the user supplies a path, the mixin must not overwrite it."""
+        s1 = _make_structure("S1", Point(0, 0, srid=SRID))
+        s2 = _make_structure("S2", Point(100, 100, srid=SRID))
+        explicit_path = LineString((0, 0), (50, 50), (100, 100), srid=SRID)
+        form = ConduitForm(
+            data={
+                "path": to_leaflet(explicit_path).geojson,
+                "start_structure": s1.pk,
+                "end_structure": s2.pk,
+                "tags": [],
+            }
+        )
+        assert form.is_valid(), form.errors
+        cleaned_path = form.cleaned_data["path"]
+        assert len(cleaned_path.coords) == 3
+
+    def test_missing_path_auto_generates_from_point_structures(self):
+        """When both structures are points and no path is given, the mixin
+        must construct a straight LineString between the two points."""
+        s1 = _make_structure("S1", Point(0, 0, srid=SRID))
+        s2 = _make_structure("S2", Point(100, 100, srid=SRID))
+        form = ConduitForm(
+            data={
+                "start_structure": s1.pk,
+                "end_structure": s2.pk,
+                "tags": [],
+            }
+        )
+        assert form.is_valid(), form.errors
+        cleaned_path = form.cleaned_data["path"]
+        assert cleaned_path.coords == ((0.0, 0.0), (100.0, 100.0))
+
+    def test_missing_path_uses_polygon_centroid(self):
+        """When a structure is a polygon, the mixin uses its centroid."""
+        poly = Polygon(((0, 0), (10, 0), (10, 10), (0, 10), (0, 0)), srid=SRID)
+        s1 = _make_structure("S1", poly)
+        s2 = _make_structure("S2", Point(100, 100, srid=SRID))
+        form = ConduitForm(
+            data={
+                "start_structure": s1.pk,
+                "end_structure": s2.pk,
+                "tags": [],
+            }
+        )
+        assert form.is_valid(), form.errors
+        start_pt = form.cleaned_data["path"].coords[0]
+        # centroid of the square (0,0)-(10,10) is (5, 5)
+        assert start_pt == (5.0, 5.0)
+
+    def test_innerduct_inherits_parent_conduit_structures(self):
+        """Innerduct fallback: when structures are omitted, inherit from
+        parent_conduit's start/end."""
+        s1 = _make_structure("S1", Point(0, 0, srid=SRID))
+        s2 = _make_structure("S2", Point(100, 100, srid=SRID))
+        parent = Conduit(
+            label="C1",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        parent.pathway_type = "conduit"
+        parent.save()
+        form = InnerductForm(
+            data={
+                "parent_conduit": parent.pk,
+                "size": "32mm",
+                "tags": [],
+            }
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["path"] is not None
+
+    def test_no_path_no_structures_raises_validation_error(self):
+        """Without a path and without structures, the mixin must reject."""
+        form = ConduitForm(data={"tags": []})
+        assert not form.is_valid()
+        assert "path" in form.errors

--- a/tests/test_route_planner_views.py
+++ b/tests/test_route_planner_views.py
@@ -1,0 +1,158 @@
+"""Tests for route-planner view helpers."""
+
+import pytest
+from django.contrib.gis.geos import Point
+
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import Structure
+from netbox_pathways.views import RoutePlannerFindView, RoutePlannerView
+
+# ---------------------------------------------------------------------------
+# RoutePlannerFindView._parse_int_list
+# ---------------------------------------------------------------------------
+
+
+class TestParseIntList:
+    def test_none_returns_none(self):
+        assert RoutePlannerFindView._parse_int_list(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert RoutePlannerFindView._parse_int_list("") is None
+
+    def test_empty_list_returns_none(self):
+        assert RoutePlannerFindView._parse_int_list([]) is None
+
+    def test_comma_separated_string(self):
+        assert RoutePlannerFindView._parse_int_list("1,2,3") == [1, 2, 3]
+
+    def test_comma_separated_with_whitespace(self):
+        assert RoutePlannerFindView._parse_int_list(" 1 , 2 , 3 ") == [1, 2, 3]
+
+    def test_list_of_ints(self):
+        assert RoutePlannerFindView._parse_int_list([1, 2, 3]) == [1, 2, 3]
+
+    def test_list_of_strings(self):
+        assert RoutePlannerFindView._parse_int_list(["1", "2"]) == [1, 2]
+
+    def test_list_of_comma_separated_strings(self):
+        # getlist may return ["1,2", "3"] when multiple form fields share a name
+        assert RoutePlannerFindView._parse_int_list(["1,2", "3"]) == [1, 2, 3]
+
+    def test_garbage_in_string_returns_none(self):
+        # All-or-nothing on the string path -- mirrors the source's try/except
+        assert RoutePlannerFindView._parse_int_list("abc") is None
+
+    def test_garbage_in_list_is_skipped(self):
+        # Per-item path tolerates garbage and keeps the valid items
+        assert RoutePlannerFindView._parse_int_list(["1", "abc", "2"]) == [1, 2]
+
+    def test_all_garbage_in_list_returns_none(self):
+        assert RoutePlannerFindView._parse_int_list(["abc", "def"]) is None
+
+
+# ---------------------------------------------------------------------------
+# RoutePlannerView._resolve_termination
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def view():
+    return RoutePlannerView()
+
+
+def _build_cable_with_terminations(*, label, site, terminate_a=True, terminate_b=True):
+    """Build a Cable with optional A-/B-side terminations rooted in `site`.
+
+    Each side is wired to an Interface on a Device in `site`, which causes
+    `CableTermination.cache_related_objects()` to populate `_site` from
+    `termination.device.site` on save.
+    """
+    from dcim.models import (
+        Cable,
+        CableTermination,
+        Device,
+        DeviceRole,
+        DeviceType,
+        Interface,
+        Manufacturer,
+    )
+    from django.contrib.contenttypes.models import ContentType
+
+    mfr, _ = Manufacturer.objects.get_or_create(name="RP-mfr", slug="rp-mfr")
+    dt, _ = DeviceType.objects.get_or_create(
+        manufacturer=mfr,
+        model="RP-dt",
+        slug="rp-dt",
+    )
+    dr, _ = DeviceRole.objects.get_or_create(name="RP-dr", slug="rp-dr")
+
+    cable = Cable.objects.create(label=label)
+    iface_ct = ContentType.objects.get_for_model(Interface)
+
+    if terminate_a:
+        dev_a = Device.objects.create(
+            name=f"{label}-devA",
+            device_type=dt,
+            role=dr,
+            site=site,
+        )
+        iface_a = Interface.objects.create(name="eth0", device=dev_a, type="1000base-t")
+        CableTermination.objects.create(
+            cable=cable,
+            cable_end="A",
+            termination_type=iface_ct,
+            termination_id=iface_a.pk,
+        )
+    if terminate_b:
+        dev_b = Device.objects.create(
+            name=f"{label}-devB",
+            device_type=dt,
+            role=dr,
+            site=site,
+        )
+        iface_b = Interface.objects.create(name="eth0", device=dev_b, type="1000base-t")
+        CableTermination.objects.create(
+            cable=cable,
+            cable_end="B",
+            termination_type=iface_ct,
+            termination_id=iface_b.pk,
+        )
+
+    return cable
+
+
+@pytest.mark.django_db
+class TestResolveTermination:
+    @pytest.fixture
+    def srid(self):
+        return get_srid()
+
+    @pytest.fixture
+    def site(self):
+        from dcim.models import Site
+
+        return Site.objects.create(name="RP-site", slug="rp-site")
+
+    @pytest.fixture
+    def structure(self, site, srid):
+        return Structure.objects.create(
+            name="RP-struct",
+            site=site,
+            location=Point(0, 0, srid=srid),
+        )
+
+    def test_no_termination_returns_none(self, view):
+        # Cable exists but has no CableTermination rows on either end
+        from dcim.models import Cable
+
+        cable = Cable.objects.create(label="RP-empty")
+        assert view._resolve_termination(cable, "A") is None
+        assert view._resolve_termination(cable, "B") is None
+
+    def test_a_side_resolves_to_structure(self, view, site, structure):
+        cable = _build_cable_with_terminations(label="RP-A", site=site, terminate_a=True, terminate_b=False)
+        assert view._resolve_termination(cable, "A") == structure
+
+    def test_b_side_resolves_to_structure(self, view, site, structure):
+        cable = _build_cable_with_terminations(label="RP-B", site=site, terminate_a=False, terminate_b=True)
+        assert view._resolve_termination(cable, "B") == structure

--- a/tests/test_route_planner_views.py
+++ b/tests/test_route_planner_views.py
@@ -9,6 +9,7 @@ from django.test import RequestFactory
 from netbox_pathways.geo import get_srid
 from netbox_pathways.models import Pathway, PlannedRoute, Structure
 from netbox_pathways.views import (
+    RoutePlannerConstraintView,
     RoutePlannerFindView,
     RoutePlannerSaveView,
     RoutePlannerView,
@@ -278,3 +279,41 @@ class TestRoutePlannerSaveView:
 
         RoutePlannerSaveView().post(request)
         assert PlannedRoute.objects.filter(name="Unnamed Route").exists()
+
+
+# ---------------------------------------------------------------------------
+# RoutePlannerConstraintView.get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRoutePlannerConstraintView:
+    def test_unknown_type_returns_400(self, factory, admin_user):
+        request = factory.get("/pathways/route-planner/constraint/?type=not_a_type")
+        request.user = admin_user
+        response = RoutePlannerConstraintView().get(request)
+        assert response.status_code == 400
+
+    def test_enum_constraint_excludes_conduit_bank(self, factory, admin_user):
+        request = factory.get(
+            "/pathways/route-planner/constraint/?type=avoid_pathway_types",
+        )
+        request.user = admin_user
+        response = RoutePlannerConstraintView().get(request)
+        assert response.status_code == 200
+        body = response.content.decode()
+        # PathwayTypeChoices includes "conduit_bank" but the constraint
+        # card filters it out -- the planner targets concrete pathways.
+        assert "conduit_bank" not in body
+
+    def test_model_constraint_renders_api_select_widget(self, factory, admin_user):
+        request = factory.get(
+            "/pathways/route-planner/constraint/?type=avoid_structures",
+        )
+        request.user = admin_user
+        response = RoutePlannerConstraintView().get(request)
+        assert response.status_code == 200
+        body = response.content.decode()
+        # Rendered widget must include the api-select hook so the frontend
+        # lazy-loads options instead of materializing all rows.
+        assert "api-select" in body

--- a/tests/test_route_planner_views.py
+++ b/tests/test_route_planner_views.py
@@ -14,6 +14,7 @@ from netbox_pathways.views import (
     RoutePlannerSaveView,
     RoutePlannerView,
 )
+from tests.conftest import build_cable_with_terminations
 
 SRID = get_srid()
 
@@ -70,67 +71,6 @@ def view():
     return RoutePlannerView()
 
 
-def _build_cable_with_terminations(*, label, site, terminate_a=True, terminate_b=True):
-    """Build a Cable with optional A-/B-side terminations rooted in `site`.
-
-    Each side is wired to an Interface on a Device in `site`, which causes
-    `CableTermination.cache_related_objects()` to populate `_site` from
-    `termination.device.site` on save.
-    """
-    from dcim.models import (
-        Cable,
-        CableTermination,
-        Device,
-        DeviceRole,
-        DeviceType,
-        Interface,
-        Manufacturer,
-    )
-    from django.contrib.contenttypes.models import ContentType
-
-    mfr, _ = Manufacturer.objects.get_or_create(name="RP-mfr", slug="rp-mfr")
-    dt, _ = DeviceType.objects.get_or_create(
-        manufacturer=mfr,
-        model="RP-dt",
-        slug="rp-dt",
-    )
-    dr, _ = DeviceRole.objects.get_or_create(name="RP-dr", slug="rp-dr")
-
-    cable = Cable.objects.create(label=label)
-    iface_ct = ContentType.objects.get_for_model(Interface)
-
-    if terminate_a:
-        dev_a = Device.objects.create(
-            name=f"{label}-devA",
-            device_type=dt,
-            role=dr,
-            site=site,
-        )
-        iface_a = Interface.objects.create(name="eth0", device=dev_a, type="1000base-t")
-        CableTermination.objects.create(
-            cable=cable,
-            cable_end="A",
-            termination_type=iface_ct,
-            termination_id=iface_a.pk,
-        )
-    if terminate_b:
-        dev_b = Device.objects.create(
-            name=f"{label}-devB",
-            device_type=dt,
-            role=dr,
-            site=site,
-        )
-        iface_b = Interface.objects.create(name="eth0", device=dev_b, type="1000base-t")
-        CableTermination.objects.create(
-            cable=cable,
-            cable_end="B",
-            termination_type=iface_ct,
-            termination_id=iface_b.pk,
-        )
-
-    return cable
-
-
 @pytest.mark.django_db
 class TestResolveTermination:
     @pytest.fixture
@@ -160,11 +100,11 @@ class TestResolveTermination:
         assert view._resolve_termination(cable, "B") is None
 
     def test_a_side_resolves_to_structure(self, view, site, structure):
-        cable = _build_cable_with_terminations(label="RP-A", site=site, terminate_a=True, terminate_b=False)
+        cable = build_cable_with_terminations(label="RP-A", site=site, terminate_a=True, terminate_b=False)
         assert view._resolve_termination(cable, "A") == structure
 
     def test_b_side_resolves_to_structure(self, view, site, structure):
-        cable = _build_cable_with_terminations(label="RP-B", site=site, terminate_a=False, terminate_b=True)
+        cable = build_cable_with_terminations(label="RP-B", site=site, terminate_a=False, terminate_b=True)
         assert view._resolve_termination(cable, "B") == structure
 
 

--- a/tests/test_route_planner_views.py
+++ b/tests/test_route_planner_views.py
@@ -1,11 +1,20 @@
 """Tests for route-planner view helpers."""
 
+from unittest.mock import patch
+
 import pytest
-from django.contrib.gis.geos import Point
+from django.contrib.gis.geos import LineString, Point
+from django.test import RequestFactory
 
 from netbox_pathways.geo import get_srid
-from netbox_pathways.models import Structure
-from netbox_pathways.views import RoutePlannerFindView, RoutePlannerView
+from netbox_pathways.models import Pathway, PlannedRoute, Structure
+from netbox_pathways.views import (
+    RoutePlannerFindView,
+    RoutePlannerSaveView,
+    RoutePlannerView,
+)
+
+SRID = get_srid()
 
 # ---------------------------------------------------------------------------
 # RoutePlannerFindView._parse_int_list
@@ -156,3 +165,116 @@ class TestResolveTermination:
     def test_b_side_resolves_to_structure(self, view, site, structure):
         cable = _build_cable_with_terminations(label="RP-B", site=site, terminate_a=False, terminate_b=True)
         assert view._resolve_termination(cable, "B") == structure
+
+
+# ---------------------------------------------------------------------------
+# RoutePlannerFindView.post
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def factory():
+    return RequestFactory()
+
+
+@pytest.fixture
+def two_structures(db):
+    s1 = Structure.objects.create(name="A", location=Point(0, 0, srid=SRID))
+    s2 = Structure.objects.create(name="B", location=Point(100, 100, srid=SRID))
+    return s1, s2
+
+
+@pytest.mark.django_db
+class TestRoutePlannerFindView:
+    def test_missing_endpoint_returns_empty_panel(self, factory, admin_user):
+        request = factory.post(
+            "/pathways/route-planner/find/",
+            {"start_structure": "1"},  # end_structure missing
+        )
+        request.user = admin_user
+        response = RoutePlannerFindView().post(request)
+        assert response.status_code == 200
+        assert b"Select both start and end structures" in response.content
+
+    def test_returns_results_panel_when_engine_returns_path(self, factory, two_structures, admin_user):
+        s1, s2 = two_structures
+        pw = Pathway.objects.create(
+            label="P1",
+            pathway_type="conduit",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+
+        request = factory.post(
+            "/pathways/route-planner/find/",
+            {
+                "start_structure": str(s1.pk),
+                "end_structure": str(s2.pk),
+                "prefer_in_use": "0",
+            },
+        )
+        request.user = admin_user
+
+        with patch(
+            "netbox_pathways.route_engine.find_route",
+            return_value=(1.0, [pw.pk]),
+        ):
+            response = RoutePlannerFindView().post(request)
+
+        assert response.status_code == 200
+        # Pathway label appears in the rendered planner_results.html fragment
+        assert b"P1" in response.content
+
+
+# ---------------------------------------------------------------------------
+# RoutePlannerSaveView.post
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRoutePlannerSaveView:
+    def test_creates_planned_route_with_name_and_pathway_ids(self, factory, two_structures, admin_user):
+        s1, s2 = two_structures
+        pw = Pathway.objects.create(
+            label="P1",
+            pathway_type="conduit",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+
+        request = factory.post(
+            "/pathways/route-planner/save/",
+            {
+                "pathway_ids": f"{pw.pk}",
+                "start_structure": str(s1.pk),
+                "end_structure": str(s2.pk),
+                "name": "My Plan",
+            },
+        )
+        request.user = admin_user
+
+        response = RoutePlannerSaveView().post(request)
+        assert response.status_code == 302  # redirect to detail
+
+        plan = PlannedRoute.objects.get(name="My Plan")
+        assert plan.start_structure_id == s1.pk
+        assert plan.end_structure_id == s2.pk
+        assert plan.pathway_ids == [pw.pk]
+
+    def test_blank_name_defaults_to_unnamed_route(self, factory, two_structures, admin_user):
+        s1, s2 = two_structures
+        request = factory.post(
+            "/pathways/route-planner/save/",
+            {
+                "pathway_ids": "",
+                "start_structure": str(s1.pk),
+                "end_structure": str(s2.pk),
+                "name": "   ",  # whitespace only
+            },
+        )
+        request.user = admin_user
+
+        RoutePlannerSaveView().post(request)
+        assert PlannedRoute.objects.filter(name="Unnamed Route").exists()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,99 @@
+"""Tests for plugin-owned signal handlers."""
+
+import pytest
+from django.contrib.gis.geos import LineString, Point
+from django.core.exceptions import ValidationError
+
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import CableSegment, Pathway, Structure
+from tests.conftest import build_cable_with_terminations
+
+SRID = get_srid()
+
+
+@pytest.fixture
+def site(db):
+    from dcim.models import Site
+
+    return Site.objects.create(name="SIG-site", slug="sig-site")
+
+
+@pytest.fixture
+def cable_and_pathway(db):
+    from dcim.models import Cable
+
+    s1 = Structure.objects.create(name="SA", location=Point(0, 0, srid=SRID))
+    s2 = Structure.objects.create(name="SB", location=Point(100, 0, srid=SRID))
+    pw = Pathway.objects.create(
+        label="P1",
+        pathway_type="conduit",
+        path=LineString((0, 0), (100, 0), srid=SRID),
+        start_structure=s1,
+        end_structure=s2,
+    )
+    cable = Cable.objects.create()
+    return cable, pw, s1, s2
+
+
+@pytest.fixture
+def pathway(db):
+    s1 = Structure.objects.create(name="SP-A", location=Point(0, 0, srid=SRID))
+    s2 = Structure.objects.create(name="SP-B", location=Point(100, 0, srid=SRID))
+    return Pathway.objects.create(
+        label="P-sig",
+        pathway_type="conduit",
+        path=LineString((0, 0), (100, 0), srid=SRID),
+        start_structure=s1,
+        end_structure=s2,
+    )
+
+
+@pytest.mark.django_db
+class TestEnforceCableRoutability:
+    def test_no_cable_id_skips_check(self, cable_and_pathway):
+        """When instance.cable_id is None, the signal returns without raising."""
+        _, pw, _, _ = cable_and_pathway
+        seg = CableSegment(cable=None, pathway=pw, sequence=1)
+        from netbox_pathways.signals import enforce_cable_routability
+
+        # Should not raise -- signal short-circuits on falsy cable_id.
+        enforce_cable_routability(sender=CableSegment, instance=seg)
+
+    def test_both_terminations_pass(self, site, pathway):
+        """When the cable has both A and B terminations, save succeeds."""
+        cable = build_cable_with_terminations(
+            label="SIG-both",
+            site=site,
+            terminate_a=True,
+            terminate_b=True,
+        )
+        seg = CableSegment.objects.create(cable=cable, pathway=pathway, sequence=1)
+        assert seg.pk is not None
+
+    def test_missing_a_termination_raises(self, site, pathway):
+        """When only B is wired, the signal raises ValidationError."""
+        cable = build_cable_with_terminations(
+            label="SIG-b-only",
+            site=site,
+            terminate_a=False,
+            terminate_b=True,
+        )
+        with pytest.raises(ValidationError, match="A and B terminations"):
+            CableSegment.objects.create(cable=cable, pathway=pathway, sequence=1)
+
+    def test_missing_b_termination_raises(self, site, pathway):
+        """When only A is wired, the signal raises ValidationError."""
+        cable = build_cable_with_terminations(
+            label="SIG-a-only",
+            site=site,
+            terminate_a=True,
+            terminate_b=False,
+        )
+        with pytest.raises(ValidationError, match="A and B terminations"):
+            CableSegment.objects.create(cable=cable, pathway=pathway, sequence=1)
+
+    def test_no_terminations_raises(self, cable_and_pathway):
+        """When neither A nor B is wired, the signal raises ValidationError."""
+        cable, pw, _, _ = cable_and_pathway
+        with pytest.raises(ValidationError, match="A and B terminations"):
+            CableSegment.objects.create(cable=cable, pathway=pw, sequence=1)


### PR DESCRIPTION
## Summary

- Adds **152 tests** across the plugin's view layer, forms, filters, graph, management commands, and signals -- targeting plugin-owned business logic only, not framework round-trips.
- Wires a CI coverage floor (`--cov-fail-under=65`) and a `codecov.yml` with project (auto) and patch (80%) status checks so future regressions block merges.
- Surfaces two real `graph.py` bugs that were discovered while writing tests (out of scope here; tracked for follow-up).

## Changes

- `pyproject.toml`: add `--cov-fail-under=65` to pytest `addopts`.
- `codecov.yml`: new, project + patch status thresholds.
- `README.md`: note that local devcontainer pytest-cov reports 0% and how to get real coverage.
- `tests/conftest.py`: lift `build_cable_with_terminations` Cable+CableTermination helper (used by 3 test files).
- `tests/test_route_planner_views.py`: new -- 21 tests covering `RoutePlannerFindView._parse_int_list`, `_resolve_termination`, `RoutePlannerFindView.post`, `RoutePlannerSaveView.post`, `RoutePlannerConstraintView.get`.
- `tests/test_cable_routing_views.py`: new -- 18 tests covering `CableRoutingMixin._far_end_node` / `_start_node` / `_end_node` / `_render_table`, `_annotate_segments`, and the add/delete/apply POST handlers.
- `tests/test_pathway_endpoint_form_mixin.py`: new -- 5 tests covering `PathwayEndpointFormMixin.clean` (explicit path kept, point auto-gen, polygon centroid, innerduct parent inherit, no-path-no-structures error).
- `tests/test_filters.py`: new -- 36 tests covering `StructureFilterSet.filter_occupied`/`filter_has_pathways`, `PathwayFilterSet.filter_structure` (including the `map_queryset` innerduct exclusion), and one substring assertion per FilterSet with a custom `search()`.
- `tests/test_graph.py`: +29 tests; `graph.py` coverage rose 58% -> 96%.
- `tests/test_import_geodata.py`: +37 tests covering `TRANSFORMS` lambdas, `Command._passes_filters`, `Command._apply_field_spec` pipeline, and `Command._load_schema`.
- `tests/test_signals.py`: new -- 5 tests pinning all branches of `enforce_cable_routability`.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/` passes locally (439 tests)
- [x] New behavior covered by tests
- [ ] CI coverage gate at 65% will be met by Codecov's measured run
- [ ] No migrations changed

## Follow-ups (out of scope for this PR)

While writing graph.py tests, two real bugs were surfaced:

1. **`_batch_fetch_junctions` field-name mismatch** -- `netbox_pathways/graph.py:474-490` calls `.only("name", "trunk_conduit__name", ...)` against `ConduitJunction` / `Pathway` which use the field `label`. Raises `FieldDoesNotExist` on any junction-node resolution path. Documented in commit `cba5fd5`. Junction-resolution tests are explicitly omitted with an inline comment until the fix lands.
2. **Dead guard in `shortest_path_nodes`** -- `netbox_pathways/graph.py:264-265` has an `if route is None: return None` after `_extract_route(...)`, but `_extract_route` always returns a tuple given a valid node list. Documented in commit `cba5fd5`.

Both should be filed as separate issues and fixed in their own PRs.

## Related

Refs: spec at `docs/superpowers/specs/2026-05-14-test-coverage-improvement-design.md` (git-excluded; local design doc).