### PR TITLE
chore: merge 0.2.2 hotfix back into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.5.8", "4.5.10"]
+        netbox: ["4.5.8", "4.5.10", "4.6.3"]
     services:
       postgres:
         image: postgis/postgis:17-3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-30
+
+### Fixed
+
+- **Geometry map widget renders blank on NetBox 4.6 / Django 6.0.** Django 6.0
+  stopped exposing the top-level `id`, `name`, and `geom_type` template-context
+  variables from `BaseGeometryWidget` (they moved under `widget`). The map
+  widget template read them at the top level, so on Django 6.0 the hidden
+  geometry input rendered with an empty `name` (the form submitted no geometry
+  and validation failed with "No geometry value submitted") and the map
+  container rendered with an empty `data-field-id` (the Leaflet/geoman
+  initializer bailed and no map appeared) -- making it impossible to add a
+  Structure or draw a Pathway. `PathwaysMapWidget.get_context` now re-exposes
+  these variables; the fix stays backwards compatible with NetBox 4.5 /
+  Django 5.2. Fixes #52.
+
 ## [0.2.1] - 2026-05-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@
 
 ## Compatibility
 
-| Plugin version | NetBox version | Python    | PostgreSQL          |
-|----------------|----------------|-----------|---------------------|
-| 0.1.x          | 4.5.3+         | 3.12-3.14 | 16+ with PostGIS 3.4|
+| Plugin version  | NetBox version       | Python    | PostgreSQL           |
+|-----------------|----------------------|-----------|----------------------|
+| 0.1.x -- 0.2.1  | 4.5.3 -- 4.5.x       | 3.12-3.14 | 16+ with PostGIS 3.4+|
+| 0.2.2+          | 4.5.3+ (incl. 4.6.x) | 3.12-3.14 | 16+ with PostGIS 3.4+|
+
+> NetBox 4.6 ships Django 6.0. Plugin versions 0.2.1 and earlier do not render
+> the geometry map widget on NetBox 4.6 (issue #52); upgrade to 0.2.2 or later
+> for NetBox 4.6 support.
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,10 +82,10 @@ The boundary is NetBox's native `dcim.Cable` model: Pathways tracks physical rou
 
 | Component    | Version                         |
 |--------------|---------------------------------|
-| NetBox       | 4.5.3+                         |
+| NetBox       | 4.5.3+ (incl. 4.6.x)            |
 | Python       | 3.12+                          |
-| PostgreSQL   | 16+ with PostGIS 3.4           |
-| Django       | 5.2+ (ships with NetBox 4.5)   |
+| PostgreSQL   | 16+ with PostGIS 3.4+          |
+| Django       | 5.2 or 6.0 (ships with NetBox) |
 | GDAL/GEOS   | System libraries for PostGIS   |
 
 ---

--- a/netbox_pathways/__init__.py
+++ b/netbox_pathways/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from netbox.plugins import PluginConfig
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 logger = logging.getLogger(__name__)
 

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -73,6 +73,14 @@ class PathwaysMapWidget(BaseGeometryWidget):
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
+        # Django 6.0 stopped exposing id/name/geom_type at the top level of the
+        # widget context (they now live under ``widget``); our template reads
+        # them at the top level, so re-expose them here. setdefault keeps this
+        # backwards compatible with Django <= 5.2, which still sets them. (#52)
+        widget = context["widget"]
+        context.setdefault("id", widget["attrs"].get("id", ""))
+        context.setdefault("name", widget["name"])
+        context.setdefault("geom_type", widget["attrs"].get("geom_name", self.geom_type))
         if self.endpoint_geojson:
             context["endpoint_json"] = mark_safe(json.dumps(self.endpoint_geojson))  # noqa: S308
         return context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ netbox_pathways = [
 
 [project]
 name = "netbox-pathways"
-version = "0.2.1"
+version = "0.2.2"
 description = "NetBox plugin for physical cable plant infrastructure documentation with GIS capabilities"
 readme = "README.md"
 authors = [
@@ -60,7 +60,7 @@ Tracker = "https://github.com/jsenecal/netbox-pathways/issues"
 Documentation = "https://jsenecal.github.io/netbox-pathways/"
 
 [tool.bumpversion]
-current_version = "0.2.1"
+current_version = "0.2.2"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/tests/test_map_widget.py
+++ b/tests/test_map_widget.py
@@ -1,0 +1,35 @@
+"""Regression tests for PathwaysMapWidget rendering.
+
+Django 6.0 changed BaseGeometryWidget.get_context so it no longer exposes the
+top-level ``id``, ``name`` and ``geom_type`` context variables that the widget
+template relies on (they moved under ``widget``). Without compensation the
+hidden input renders with an empty ``name`` (so no geometry is submitted) and
+the map container renders with an empty ``data-field-id`` (so the JS bails and
+no map appears). See issue #52.
+"""
+
+from netbox_pathways.forms import PathwaysMapWidget
+
+
+def _render(widget):
+    return widget.render("location", None, attrs={"id": "id_location"})
+
+
+def test_hidden_input_keeps_field_name():
+    """The hidden geometry input must carry name="location" so the form submits a value."""
+    html = _render(PathwaysMapWidget(geom_type="Geometry"))
+    assert 'name="location"' in html
+    assert 'name=""' not in html
+
+
+def test_map_container_has_field_id():
+    """The map container needs a non-empty data-field-id for the JS to initialize."""
+    html = _render(PathwaysMapWidget(geom_type="Geometry"))
+    assert 'data-field-id="id_location"' in html
+    assert 'data-field-id=""' not in html
+
+
+def test_geom_type_is_exposed():
+    """The configured geometry type must reach the template's data-geom-type."""
+    assert 'data-geom-type="Geometry"' in _render(PathwaysMapWidget(geom_type="Geometry"))
+    assert 'data-geom-type="LineString"' in _render(PathwaysMapWidget(geom_type="LineString"))


### PR DESCRIPTION
## Summary
- Brings the 0.2.2 hotfix (issue #52: geometry map widget blank on NetBox 4.6 / Django 6.0) back into main.
- Advances the version baseline to 0.2.2; the in-flight features stay under `[Unreleased]` for the next (0.3.0) release.

## Changes
- `netbox_pathways/forms.py`: `PathwaysMapWidget.get_context` re-exposes the `id`/`name`/`geom_type` template-context vars that Django 6.0 dropped from `BaseGeometryWidget`.
- `tests/test_map_widget.py`: regression tests for the widget render.
- `CHANGELOG.md`: new `## [0.2.2] - 2026-06-30` section (Fixed #52); `[Unreleased]` features preserved.
- `README.md`, `docs/index.md`: NetBox 4.6 / Django 6.0 compatibility notes.
- version bump 0.2.1 -> 0.2.2 (merged from `release/0.2.2`).

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (459 + 3 new, on NetBox 4.6.3 / Django 6.0.6)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (n/a -- no schema change)
- [x] Docs updated (README, CHANGELOG, docs/)

## Related
Refs: #52
