### PR TITLE
fix(models): allow pathless pathways between two locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`Pathway.path` is now optional for indoor pathways.** A pathway whose both
+  endpoints are locations (rooms, floors) can be saved without a geographic
+  path -- NetBox locations carry no coordinates, so previously such pathways
+  could not be created at all without drawing a meaningless map line. A path
+  is still required whenever either endpoint is geographic (a structure or,
+  for conduits, a junction); this rule now lives in `Pathway.clean()` instead
+  of the database NOT NULL constraint. Pathless indoor pathways are excluded
+  from the GeoJSON map layers. Innerducts now inherit locations (not just
+  structures) from their parent conduit, at validation time as well as save
+  time. Migration `0019_alter_pathway_path`.
 - **`AerialSpan.attachment_height` is now per-endpoint.** The single
   `attachment_height` field is replaced by `start_attachment_height` and
   `end_attachment_height` (both nullable floats, meters). A read-only

--- a/docs/user-guide/pathways.md
+++ b/docs/user-guide/pathways.md
@@ -1,6 +1,6 @@
 # Pathways
 
-Pathways represent the physical routes that cables follow between structures and locations. Each pathway has a LineString geometry defining its geographic path.
+Pathways represent the physical routes that cables follow between structures and locations. Outdoor pathways have a LineString geometry defining their geographic path; indoor pathways (between two locations) have no geometry.
 
 ## Pathway Types
 
@@ -55,7 +55,7 @@ A smaller duct installed inside a parent conduit to subdivide capacity.
 | Color | Innerduct color for identification |
 | Position | Position within the parent conduit |
 
-Innerducts inherit start and end structures from their parent conduit if not explicitly set.
+Innerducts inherit start and end endpoints (structures or locations) from their parent conduit if not explicitly set.
 
 ## Endpoints
 
@@ -66,6 +66,10 @@ Every pathway has a start endpoint and an end endpoint. These can be:
 - **Junction** — A conduit junction (conduits only)
 
 You can mix endpoint types. For example, a conduit starting at a manhole (structure) and ending at an equipment room (location) models a building entrance path.
+
+### Indoor pathways
+
+When both endpoints are locations, the pathway is indoor and the geographic path is optional -- NetBox locations carry no coordinates, so there is nothing to draw. Simply pick the two locations and save; the pathway is created without geometry and does not appear on the interactive map or in the GeoJSON API layers. A path is still required whenever either endpoint is geographic (a structure or a junction).
 
 ## Creating a Pathway
 

--- a/netbox_pathways/api/geo.py
+++ b/netbox_pathways/api/geo.py
@@ -299,8 +299,10 @@ class StructureGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
 
 
 class PathwayGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
+    # Indoor (location-to-location) pathways have no path and cannot be mapped
     queryset = (
-        models.Pathway.objects.only(
+        models.Pathway.objects.filter(path__isnull=False)
+        .only(
             "id",
             "label",
             "pathway_type",
@@ -317,7 +319,8 @@ class PathwayGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
 
 class ConduitBankGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
     queryset = (
-        models.ConduitBank.objects.annotate(
+        models.ConduitBank.objects.filter(path__isnull=False)
+        .annotate(
             conduit_count=Count("conduits"),
             _geo_length=Length("path"),
         )
@@ -341,6 +344,7 @@ class ConduitGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
     queryset = (
         models.Conduit.objects.filter(
             conduit_bank__isnull=True,
+            path__isnull=False,
         )
         .annotate(_geo_length=Length("path"))
         .only(
@@ -359,7 +363,8 @@ class ConduitGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
 
 class AerialSpanGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
     queryset = (
-        models.AerialSpan.objects.only(
+        models.AerialSpan.objects.filter(path__isnull=False)
+        .only(
             "id",
             "label",
             "pathway_type",
@@ -376,7 +381,8 @@ class AerialSpanGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
 
 class DirectBuriedGeoViewSet(BboxFilterMixin, ReadOnlyModelViewSet):
     queryset = (
-        models.DirectBuried.objects.only(
+        models.DirectBuried.objects.filter(path__isnull=False)
+        .only(
             "id",
             "label",
             "pathway_type",

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -121,17 +121,26 @@ class PathwayEndpointFormMixin:
         if path:
             return cleaned
 
-        # Auto-generate path from structures
         start_struct = cleaned.get("start_structure")
         end_struct = cleaned.get("end_structure")
+        start_loc = cleaned.get("start_location")
+        end_loc = cleaned.get("end_location")
 
-        # Innerduct fallback: use parent conduit's structures
-        if not start_struct and not end_struct:
-            parent = cleaned.get("parent_conduit")
-            if parent:
-                start_struct = start_struct or parent.start_structure
-                end_struct = end_struct or parent.end_structure
+        # Innerduct fallback: use parent conduit's endpoints, per side
+        parent = cleaned.get("parent_conduit")
+        if parent:
+            if not start_struct and not start_loc:
+                start_struct = parent.start_structure
+                start_loc = parent.start_location
+            if not end_struct and not end_loc:
+                end_struct = parent.end_structure
+                end_loc = parent.end_location
 
+        # Indoor pathway (both endpoints are locations): no geographic path exists
+        if start_loc and end_loc and not start_struct and not end_struct:
+            return cleaned
+
+        # Auto-generate path from structures
         if start_struct and end_struct and start_struct.location and end_struct.location:
             start_geom = start_struct.location
             end_geom = end_struct.location
@@ -145,7 +154,12 @@ class PathwayEndpointFormMixin:
         else:
             from django.core.exceptions import ValidationError
 
-            raise ValidationError({"path": "Path is required when both endpoint structures are not set."})
+            raise ValidationError(
+                {
+                    "path": "Path is required unless both endpoints are structures "
+                    "(auto-generated) or both are locations (indoor)."
+                }
+            )
 
         return cleaned
 

--- a/netbox_pathways/migrations/0019_alter_pathway_path.py
+++ b/netbox_pathways/migrations/0019_alter_pathway_path.py
@@ -1,0 +1,20 @@
+import django.contrib.gis.db.models.fields
+from django.db import migrations
+
+from netbox_pathways.geo import get_srid
+
+_SRID = get_srid()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_pathways", "0018_aerialspan_attachment_height_per_side"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="pathway",
+            name="path",
+            field=django.contrib.gis.db.models.fields.LineStringField(blank=True, null=True, srid=_SRID),
+        ),
+    ]

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -221,7 +221,12 @@ class Pathway(NetBoxModel):
 
     label = models.CharField(max_length=100, blank=True)
     pathway_type = models.CharField(max_length=50, choices=PathwayTypeChoices, editable=False)
-    path = models.LineStringField(srid=get_srid(), help_text="Geographic path")
+    path = models.LineStringField(
+        srid=get_srid(),
+        null=True,
+        blank=True,
+        help_text="Geographic path (not applicable to indoor pathways between two locations)",
+    )
     start_structure = models.ForeignKey(
         Structure,
         on_delete=models.PROTECT,
@@ -294,6 +299,16 @@ class Pathway(NetBoxModel):
         return self.end_structure or self.end_location
 
     @property
+    def is_indoor(self):
+        """Both endpoints are dcim.Locations, which carry no geometry."""
+        return bool(
+            self.start_location_id
+            and self.end_location_id
+            and not self.start_structure_id
+            and not self.end_structure_id
+        )
+
+    @property
     def geo_length(self):
         """Length of `path` in metres, computed by PostGIS `ST_Length`.
 
@@ -313,6 +328,10 @@ class Pathway(NetBoxModel):
     def clean(self):
         super().clean()
         if not self.path:
+            if not self.is_indoor:
+                raise ValidationError(
+                    {"path": "Path is required unless both endpoints are locations (indoor pathway)."}
+                )
             return
         self._validate_and_snap_endpoint("start")
         self._validate_and_snap_endpoint("end")
@@ -509,6 +528,11 @@ class Conduit(Pathway):
     def map_visible(self):
         return self.conduit_bank_id is None
 
+    @property
+    def is_indoor(self):
+        """Junction endpoints are geographic, so they also preclude indoor status."""
+        return super().is_indoor and not self.start_junction_id and not self.end_junction_id
+
     class Meta:
         verbose_name = "Conduit"
         verbose_name_plural = "Conduits"
@@ -656,17 +680,26 @@ class Innerduct(Pathway):
         verbose_name = "Innerduct"
         verbose_name_plural = "Innerducts"
 
+    def _inherit_parent_endpoints(self):
+        """Inherit endpoints from the parent conduit, per side, if not explicitly set."""
+        if not self.parent_conduit_id:
+            return
+        if not any([self.start_structure_id, self.start_location_id]):
+            self.start_structure = self.parent_conduit.start_structure
+            self.start_location = self.parent_conduit.start_location
+        if not any([self.end_structure_id, self.end_location_id]):
+            self.end_structure = self.parent_conduit.end_structure
+            self.end_location = self.parent_conduit.end_location
+
+    def clean(self):
+        # Inherit before validation so the path-required check sees the
+        # effective endpoints, not just the explicitly set ones.
+        self._inherit_parent_endpoints()
+        super().clean()
+
     def save(self, *args, **kwargs):
         self.pathway_type = "innerduct"
-        if self.parent_conduit_id:
-            # Inherit start endpoint from parent if not explicitly set
-            if not any([self.start_structure_id, self.start_location_id]):
-                self.start_structure = self.parent_conduit.start_structure
-                self.start_location = self.parent_conduit.start_location
-            # Inherit end endpoint from parent if not explicitly set
-            if not any([self.end_structure_id, self.end_location_id]):
-                self.end_structure = self.parent_conduit.end_structure
-                self.end_location = self.parent_conduit.end_location
+        self._inherit_parent_endpoints()
         super().save(*args, **kwargs)
 
 

--- a/tests/test_endpoint_validation.py
+++ b/tests/test_endpoint_validation.py
@@ -52,10 +52,11 @@ class TestPathwayEndpointValidation:
         pw = _make_pathway(path)
         pw.clean()
 
-    def test_no_path_skips_validation(self):
+    def test_no_path_with_structure_endpoint_raises(self):
         struct = _make_structure("S4", Point(100, 200, srid=SRID))
         pw = _make_pathway(path=None, start_structure=struct)
-        pw.clean()
+        with pytest.raises(ValidationError, match="[Pp]ath"):
+            pw.clean()
 
     def test_polygon_structure_inside_snaps_to_boundary(self):
         poly = Polygon(((0, 0), (100, 0), (100, 100), (0, 100), (0, 0)), srid=SRID)

--- a/tests/test_indoor_pathways.py
+++ b/tests/test_indoor_pathways.py
@@ -1,0 +1,142 @@
+"""Tests for pathless indoor (location-to-location) pathways.
+
+A pathway whose both endpoints are dcim.Locations is indoor: locations carry
+no geometry, so no geographic path can exist for it. `path` must be optional
+in that case and remain required whenever a geographic endpoint (structure or
+junction) is set.
+"""
+
+import pytest
+from dcim.models import Location, Site
+from django.contrib.gis.geos import LineString, Point
+from django.core.exceptions import ValidationError
+
+from netbox_pathways.forms import ConduitForm, InnerductForm
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import Conduit, ConduitJunction, Structure
+
+SRID = get_srid()
+
+
+@pytest.fixture
+def locations(db):
+    site = Site.objects.create(name="Indoor Site", slug="indoor-site")
+    loc_a = Location.objects.create(site=site, name="Room A", slug="room-a")
+    loc_b = Location.objects.create(site=site, name="Room B", slug="room-b")
+    return loc_a, loc_b
+
+
+def _make_structure(name, geom):
+    return Structure.objects.create(name=name, location=geom)
+
+
+def _make_conduit(**kwargs):
+    c = Conduit(**kwargs)
+    c.pathway_type = "conduit"
+    return c
+
+
+@pytest.mark.django_db
+class TestIndoorPathwayModelValidation:
+    def test_location_to_location_conduit_without_path_validates(self, locations):
+        loc_a, loc_b = locations
+        c = _make_conduit(start_location=loc_a, end_location=loc_b)
+        c.full_clean()
+        c.save()
+        assert c.pk is not None
+        assert c.path is None
+
+    def test_structure_endpoint_without_path_raises(self, locations):
+        _, loc_b = locations
+        s1 = _make_structure("IP1", Point(0, 0, srid=SRID))
+        c = _make_conduit(start_structure=s1, end_location=loc_b)
+        with pytest.raises(ValidationError) as exc:
+            c.full_clean()
+        assert "path" in exc.value.message_dict
+
+    def test_junction_endpoint_without_path_raises(self, locations):
+        _, loc_b = locations
+        s1 = _make_structure("IP2", Point(0, 0, srid=SRID))
+        s2 = _make_structure("IP3", Point(1000, 0, srid=SRID))
+        trunk = _make_conduit(
+            path=LineString((0, 0), (1000, 0), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        trunk.save()
+        branch = _make_conduit(
+            path=LineString((500, 100), (500, 500), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        branch.save()
+        junction = ConduitJunction.objects.create(
+            trunk_conduit=trunk,
+            branch_conduit=branch,
+            towards_structure=s1,
+            position_on_trunk=0.5,
+        )
+        c = _make_conduit(start_junction=junction, end_location=loc_b)
+        with pytest.raises(ValidationError) as exc:
+            c.full_clean()
+        assert "path" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+class TestIndoorPathwayForms:
+    def test_conduit_form_between_two_locations_is_valid(self, locations):
+        loc_a, loc_b = locations
+        form = ConduitForm(
+            data={
+                "start_location": loc_a.pk,
+                "end_location": loc_b.pk,
+                "tags": [],
+            }
+        )
+        assert form.is_valid(), form.errors
+        obj = form.save()
+        assert obj.pk is not None
+        assert obj.path is None
+
+    def test_conduit_form_structure_and_location_without_path_errors(self, locations):
+        _, loc_b = locations
+        s1 = _make_structure("IPF1", Point(0, 0, srid=SRID))
+        form = ConduitForm(
+            data={
+                "start_structure": s1.pk,
+                "end_location": loc_b.pk,
+                "tags": [],
+            }
+        )
+        assert not form.is_valid()
+        assert "path" in form.errors
+
+    def test_innerduct_form_inherits_indoor_parent_locations(self, locations):
+        loc_a, loc_b = locations
+        parent = _make_conduit(start_location=loc_a, end_location=loc_b)
+        parent.save()
+        form = InnerductForm(
+            data={
+                "parent_conduit": parent.pk,
+                "size": "32mm",
+                "tags": [],
+            }
+        )
+        assert form.is_valid(), form.errors
+        obj = form.save()
+        assert obj.path is None
+        assert obj.start_location == loc_a
+        assert obj.end_location == loc_b
+
+
+@pytest.mark.django_db
+class TestIndoorGeoLayers:
+    def test_indoor_conduit_excluded_from_geo_layers(self, locations):
+        """Pathless indoor pathways must not appear in GeoJSON map layers."""
+        from netbox_pathways.api.geo import ConduitGeoViewSet, PathwayGeoViewSet
+
+        loc_a, loc_b = locations
+        c = _make_conduit(start_location=loc_a, end_location=loc_b)
+        c.save()
+        assert not ConduitGeoViewSet.queryset.filter(pk=c.pk).exists()
+        assert not PathwayGeoViewSet.queryset.filter(pk=c.pk).exists()


### PR DESCRIPTION
## Summary
- Pathways between two dcim.Locations (indoor) could not be created: the path field was NOT NULL and the form only auto-generates a path from structure endpoints, while locations carry no coordinates.
- path is now nullable; the requirement moved into Pathway.clean() and applies whenever either endpoint is geographic (structure or, for conduits, junction). Pathless indoor pathways are excluded from the GeoJSON map layers.
- Innerducts now inherit locations (not just structures) from their parent conduit, at validation time as well as save time.

## Changes
- netbox_pathways/models.py: Pathway.path null/blank, is_indoor property (Conduit override for junctions), path-required rule in clean(), Innerduct endpoint inheritance extracted and run in clean()
- netbox_pathways/forms.py: PathwayEndpointFormMixin accepts pathless indoor pathways; innerduct parent fallback per side for structures and locations
- netbox_pathways/api/geo.py: pathway GeoJSON layers filter path__isnull=False
- netbox_pathways/migrations/0019_alter_pathway_path.py: alter field (uses _SRID convention)
- tests/test_indoor_pathways.py: regression tests (model, forms, innerduct inheritance, geo-layer exclusion)
- tests/test_endpoint_validation.py: path-required rule now surfaces in clean() instead of the DB constraint
- CHANGELOG.md, docs/user-guide/pathways.md: document indoor pathways

## Testing
- [x] ruff check passes
- [x] ruff format --check passes
- [x] pytest passes locally (466 passed, coverage 73%)
- [x] New/changed behavior covered by tests
- [x] Migration applied cleanly
- [x] Docs updated (CHANGELOG, zensical pages)

## Related
Refs: none (reported interactively)