### PR TITLE
fix(views): map extent crash when a structure has a polygon footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Map page crashed when any structure had a polygon footprint.** The
+  initial-extent query trimmed GPS outliers with `ST_X()`/`ST_Y()` on raw
+  structure locations, but those functions only accept points, so a single
+  polygon-footprint structure raised `InternalError: Argument to ST_Y() must
+  have type POINT` and 500ed the map and route planner. Outlier trimming now
+  compares each geometry's centroid (identical behavior for points) while the
+  extent itself still uses the full geometry, so footprints are covered edge
+  to edge. Fixes #71.
 - **List-view Import buttons were dead links.** The plugin registered its
   import URLs as `<model>_import`, but NetBox's list-view `BulkImport` action
   reverses `<model>_bulk_import`, so every Import button on object tables

--- a/netbox_pathways/views.py
+++ b/netbox_pathways/views.py
@@ -1679,22 +1679,26 @@ class MapView(LoginRequiredMixin, View):
         bbox = None
 
         with connection.cursor() as cursor:
-            # Structures — trimmed extent to reject outliers
+            # Structures — trimmed extent to reject outliers. Locations may be
+            # any geometry (polygon footprints), and ST_X/ST_Y only accept
+            # points, so trim on each row's centroid; extents still use the
+            # full geometry so footprints are covered edge to edge.
             cursor.execute("""
                 WITH pts AS (
-                    SELECT ST_Transform(location, 4326) AS geom
+                    SELECT ST_Transform(location, 4326) AS geom,
+                           ST_Centroid(ST_Transform(location, 4326)) AS ctr
                     FROM netbox_pathways_structure
                     WHERE location IS NOT NULL
                 ),
                 med AS (
-                    SELECT ST_Y(ST_Centroid(ST_Collect(geom))) AS lat,
-                           ST_X(ST_Centroid(ST_Collect(geom))) AS lon
+                    SELECT ST_Y(ST_Centroid(ST_Collect(ctr))) AS lat,
+                           ST_X(ST_Centroid(ST_Collect(ctr))) AS lon
                     FROM pts
                 ),
                 trimmed AS (
                     SELECT pts.geom FROM pts, med
-                    WHERE abs(ST_Y(pts.geom) - med.lat) < 2
-                      AND abs(ST_X(pts.geom) - med.lon) < 2
+                    WHERE abs(ST_Y(pts.ctr) - med.lat) < 2
+                      AND abs(ST_X(pts.ctr) - med.lon) < 2
                 )
                 SELECT ST_Extent(geom) FROM trimmed
             """)

--- a/tests/test_map_view.py
+++ b/tests/test_map_view.py
@@ -87,6 +87,26 @@ class TestSafeCasts:
 
 @pytest.mark.django_db
 class TestDataExtent:
+    @staticmethod
+    def _structure_at(name, lon, lat):
+        location = Point(lon, lat, srid=4326)
+        location.transform(get_srid())
+        return Structure.objects.create(name=name, location=location, structure_type="manhole")
+
+    def test_outlier_structures_trimmed(self):
+        """Structures more than 2 degrees from the cluster's mean position are
+        excluded from the initial extent, so one bad GPS fix cannot zoom the
+        whole map out."""
+        for i in range(5):
+            self._structure_at(f"Extent-Cluster-{i}", -73.6 + i * 0.01, 45.5)
+        self._structure_at("Extent-Outlier", -78.6, 45.5)
+
+        west, south, east, north = MapView()._data_extent()
+
+        assert west >= -74  # outlier at -78.6 trimmed away
+        assert east <= -73
+        assert 45 <= south <= north <= 46
+
     def test_polygon_footprint_structure(self):
         """Regression for #71: ST_Y() only accepts points, so a structure with
         a polygon footprint must not break the trimmed-extent query."""

--- a/tests/test_map_view.py
+++ b/tests/test_map_view.py
@@ -1,10 +1,13 @@
-"""Tests for MapView — kiosk param, URL params, parse_box, safe casts."""
+"""Tests for MapView — kiosk param, URL params, parse_box, safe casts, data extent."""
 
 from unittest.mock import patch
 
 import pytest
+from django.contrib.gis.geos import Point, Polygon
 from django.test import RequestFactory
 
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import Structure
 from netbox_pathways.views import MapView
 
 
@@ -75,6 +78,42 @@ class TestSafeCasts:
     def test_safe_int_float_string(self, view):
         # float strings are not valid ints
         assert view._safe_int("3.5", 1) == 1
+
+
+# ---------------------------------------------------------------------------
+# _data_extent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDataExtent:
+    def test_polygon_footprint_structure(self):
+        """Regression for #71: ST_Y() only accepts points, so a structure with
+        a polygon footprint must not break the trimmed-extent query."""
+        srid = get_srid()
+        Structure.objects.create(
+            name="Extent-Point",
+            location=Point(100, 100, srid=srid),
+            structure_type="manhole",
+        )
+        Structure.objects.create(
+            name="Extent-Footprint",
+            location=Polygon(((0, 0), (50, 0), (50, 50), (0, 50), (0, 0)), srid=srid),
+            structure_type="vault",
+        )
+
+        extent = MapView()._data_extent()
+
+        assert extent is not None
+        west, south, east, north = extent
+        # The footprint's full extent (not just its centroid) must be covered:
+        # its (0, 0) corner is the bbox's southwest, the point its northeast.
+        origin = Point(0, 0, srid=srid)
+        origin.transform(4326)
+        assert west <= origin.x
+        assert south <= origin.y
+        assert east > west
+        assert north > south
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The map page (and route planner, which reuses the same extent helper) 500ed with `InternalError: Argument to ST_Y() must have type POINT` as soon as any structure had a polygon footprint -- a documented use of `Structure.location` (GeometryField, "polygon for footprints").
- Root cause: the initial-extent query trims GPS outliers by applying `ST_X()`/`ST_Y()` to each raw structure geometry, and PostGIS rejects those functions for anything but a point.
- Outlier trimming now compares each geometry's centroid (identical behavior for points), while `ST_Extent` still consumes the full geometry so footprints contribute their entire bounds.

## Changes
- `netbox_pathways/views.py`: `MapView._data_extent()` gains a per-row `ctr` (centroid) column used by the median CTE and the 2-degree outlier comparison; the final extent still uses the raw geometry.
- `tests/test_map_view.py`: regression test creating a point structure plus a polygon-footprint structure; asserts `_data_extent()` returns a bbox reaching the footprint's corner (guards against collapsing footprints to centroids). Fails with the exact production error on main.
- `CHANGELOG.md`: entry under `[Unreleased]` > Fixed.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (509 passed, coverage 74.08%)
- [x] New/changed behavior covered by tests
- [x] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG; no README/docs pages affected)

## Related
Fixes #71
