### PR TITLE
feat(models): round geo_length display to configurable decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rounded `geo_length` display** -- computed pathway lengths are now rounded
+  to 2 decimals (centimetres) by default instead of showing 12 decimal
+  digits; even survey-grade GPS tops out around centimetre accuracy, so the
+  extra digits were noise. A new
+  `PLUGINS_CONFIG['netbox_pathways']['geo_length_decimals']` setting (default
+  `2`, `0` = whole metres) controls how many decimal digits appear in tables,
+  detail panels, and the REST/GeoJSON APIs. Sorting and
+  `geo_length__gte`/`__lte` filtering are unaffected -- they always use the
+  full-precision PostGIS value. Fixes #80.
 - **`LICENSE` file (AGPL-3.0-or-later).** The project is now explicitly licensed under the GNU Affero General Public License v3.0 or later. The README previously referenced Apache 2.0 but no license file was ever shipped; `pyproject.toml` now declares the SPDX expression `AGPL-3.0-or-later` so PyPI metadata matches.
 - **Status on the interactive map** -- the sidebar details pane now shows the clicked feature's lifecycle status as a colored badge, and a new **Hide inactive** toggle (with a gear panel choosing which statuses count as inactive, default `retired` + `abandoned`; persisted in localStorage) removes those features from every map layer. Filtering happens server-side: the GeoJSON layer endpoints and the `/info` count endpoint accept `exclude_status` (comma-separated or repeated), so viewport counts and clustering thresholds stay consistent with what is drawn. `/info` also returns the available `statuses` (value, label, color) for building filter UIs. Circuit routes are unaffected (circuits carry NetBox core statuses). Refs #68.
 - **Skip-info band + optimistic `/info` revalidation on the map.** Panning and zooming no longer block on a fresh `/info` round-trip before the GeoJSON layers start loading. The frontend now uses a three-band strategy: below `MIN_DATA_ZOOM` (11) nothing renders; in the gated band, if a recent `/info` is cached the cached decision drives the immediate render and `/info` revalidates in the background with `If-None-Match` (a 304 leaves the screen untouched, a 200 reconciles only if the decision actually changed); at or above `SKIP_INFO_ZOOM` (default 17) `/info` is skipped entirely because the viewport is too small to plausibly cross any hide/cluster threshold. Configurable via `PLUGINS_CONFIG['netbox_pathways']['map_skip_info_zoom']` if a deployment hits the edge case. The pure decision logic lives in `netbox_pathways/static/netbox_pathways/src/load-strategy.ts` (`chooseLoadStrategy`, `decideSkipInfo`, `decisionsDiffer`) and is covered by vitest. `fetchMapInfo`'s callback now also signals whether the response was a 200 (fresh) or 304 (unchanged), so callers can skip the reconciliation render in the common case.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -38,6 +38,17 @@ PLUGINS_CONFIG = {
 | `map_base_layers`    | `list`  | --                               | Custom base layer definitions (see below)|
 | `map_overlays`       | `list`  | `[]`                            | WMS/WMTS/tile overlay layers             |
 
+## Display Settings
+
+| Setting               | Type  | Default | Description                                                              |
+|-----------------------|-------|---------|--------------------------------------------------------------------------|
+| `geo_length_decimals` | `int` | `2`     | Decimal digits shown on computed `geo_length` values (`0` = whole metres) |
+
+Computed pathway lengths (`geo_length`) are rounded for display and API
+output -- centimetre precision by default, matching the best survey-grade
+GPS accuracy; sorting and filtering always use the full-precision PostGIS
+value.
+
 ## Tile Providers
 
 By default the plugin uses OpenStreetMap tiles. For better zoom levels, dark mode support, and satellite imagery, we recommend configuring Mapbox base layers via the Styles API. A free Mapbox account provides 200,000 tile requests/month.

--- a/netbox_pathways/__init__.py
+++ b/netbox_pathways/__init__.py
@@ -25,6 +25,8 @@ class NetBoxPathwaysConfig(PluginConfig):
         "map_max_native_zoom": 19,
         "map_attribution": "&copy; OpenStreetMap contributors",
         "map_overlays": [],
+        # Decimal digits shown on computed geo_length values (0 = whole metres)
+        "geo_length_decimals": 2,
     }
     django_apps = [
         "django.contrib.gis",

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -1,5 +1,6 @@
 from circuits.models import Circuit
 from dcim.models import Cable, Location, Site
+from django.conf import settings
 from django.contrib.gis.db import models
 from django.contrib.gis.db.models.functions import Length
 from django.core.exceptions import ValidationError
@@ -201,12 +202,20 @@ class CircuitGeometry(NetBoxModel):
 
 
 def _distance_to_m(value):
-    """Coerce a GeoDjango Distance (or numeric) to a float in metres."""
+    """Coerce a GeoDjango Distance (or numeric) to rounded metres.
+
+    geo_length is a display value and GPS accuracy tops out around
+    centimetres, so it is rounded to 2 decimals by default; deployments
+    adjust via `PLUGINS_CONFIG['netbox_pathways']['geo_length_decimals']`
+    (0 = whole metres).
+    """
     if value is None:
         return None
-    if hasattr(value, "m"):
-        return value.m
-    return float(value)
+    metres = value.m if hasattr(value, "m") else float(value)
+    decimals = settings.PLUGINS_CONFIG.get("netbox_pathways", {}).get("geo_length_decimals", 2)
+    if decimals <= 0:
+        return round(metres)
+    return round(metres, decimals)
 
 
 class PathwayQuerySet(RestrictedQuerySet):

--- a/tests/test_geo_length.py
+++ b/tests/test_geo_length.py
@@ -115,6 +115,41 @@ class TestGeoLengthProperty:
 
 
 @pytest.mark.django_db
+class TestGeoLengthRounding:
+    """`geo_length` is a display value: survey-grade GPS is centimetre-scale
+    at best, so the property rounds to 2 decimals (centimetres) by default,
+    overridable via `PLUGINS_CONFIG['netbox_pathways']['geo_length_decimals']`
+    (0 = whole metres). Refs #80.
+    """
+
+    @pytest.fixture
+    def diagonal_conduit(self, structures, srid):
+        # sqrt(1000^2 + 1000^2) = 1414.2135623730951 m
+        return Conduit.objects.create(
+            label="GL-diag",
+            start_structure=structures[0],
+            end_structure=structures[1],
+            path=LineString((0.0, 0.0), (1000.0, 1000.0), srid=srid),
+        )
+
+    def test_default_rounds_to_centimetres(self, diagonal_conduit):
+        instance = Pathway.objects.with_geo_length().get(pk=diagonal_conduit.pk)
+        assert instance.geo_length == pytest.approx(1414.21)
+
+    def test_fallback_path_also_rounds(self, diagonal_conduit):
+        instance = Pathway.objects.get(pk=diagonal_conduit.pk)
+        assert instance.geo_length == pytest.approx(1414.21)
+
+    def test_zero_decimals_rounds_to_whole_metres(self, diagonal_conduit, settings):
+        settings.PLUGINS_CONFIG["netbox_pathways"]["geo_length_decimals"] = 0
+        try:
+            instance = Pathway.objects.with_geo_length().get(pk=diagonal_conduit.pk)
+            assert instance.geo_length == 1414
+        finally:
+            del settings.PLUGINS_CONFIG["netbox_pathways"]["geo_length_decimals"]
+
+
+@pytest.mark.django_db
 class TestGeoLengthFilterSet:
     """`PathwayFilterSet.geo_length__gte` / `__lte` must filter via PostGIS,
     not Python, even when the list view's queryset already paid for the


### PR DESCRIPTION
## Summary
- Computed `geo_length` values showed a raw 12-decimal float in tables, detail panels, and the REST/GeoJSON APIs; even survey-grade GPS tops out around centimetre accuracy, so the extra digits were noise.
- Lengths are now rounded to 2 decimals (centimetres) by default, configurable via `PLUGINS_CONFIG['netbox_pathways']['geo_length_decimals']` (`0` = whole metres) -- covering both the issue's first approach and its proposed alternative.
- Rounding happens in the `geo_length` property, the single choke point every display surface reads. Sorting and `geo_length__gte`/`__lte` filters are unaffected: they operate on the DB-side `_geo_length` annotation at full precision.

## Changes
- `netbox_pathways/models.py`: `_distance_to_m()` (used only by the `geo_length` property) rounds to the configured number of decimals; `0` or negative yields whole-metre ints.
- `netbox_pathways/__init__.py`: `geo_length_decimals: 2` added to `default_settings`.
- `tests/test_geo_length.py`: new `TestGeoLengthRounding` (3 tests on a 1414.2135623730951 m diagonal path): default centimetre rounding on both the annotated and fallback code paths, and the `0`-decimals override.
- `docs/getting-started/configuration.md`: new "Display Settings" section documenting the setting.
- `CHANGELOG.md`: entry under `[Unreleased]` > Added.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (513 passed, coverage 74.11%)
- [x] New/changed behavior covered by tests
- [x] Migration applied cleanly (no schema change)
- [x] Docs updated (configuration page + CHANGELOG)

## Related
Fixes #80
