### PR TITLE
fix(views): build map client config as JSON, not template interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The map and route planner failed to load for users on a non-English
+  locale.** Django localizes numbers when a template renders them, so under
+  a language that uses a comma as the decimal separator (German, French,
+  Spanish, ...) the map center was written into the page as
+  `center: [52,42, 10,78]` -- a four-element array -- and Leaflet threw
+  `TypeError: null is not an object (evaluating 't.lat')`, leaving a blank
+  map. The client config is now built in the view and emitted with Django's
+  `json_script`, which is locale-independent and escapes the payload against
+  script-tag breakout. Reported and diagnosed by @JulianJacobi. Fixes #93.
+
 - **The map panel on a Location detail page ignored the structures in that
   location.** It only drew pathways whose start or end was the location, plus
   those pathways' endpoint structures -- so a location holding structures but

--- a/netbox_pathways/templates/netbox_pathways/map.html
+++ b/netbox_pathways/templates/netbox_pathways/map.html
@@ -460,7 +460,7 @@
         color: var(--tblr-body-color, #212529);
     }
 </style>
-<div class="pathways-map-wrapper{% if kiosk %} pw-kiosk{% endif %}">
+<div class="pathways-map-wrapper{% if map_init_config.kiosk %} pw-kiosk{% endif %}">
     <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
             <h3 class="card-title mb-0">Infrastructure Map</h3>
@@ -474,7 +474,7 @@
                 </div>
                 <div id="pw-sidebar" class="pw-sidebar">
                     <!-- Kiosk close button -->
-                    {% if kiosk %}
+                    {% if map_init_config.kiosk %}
                     <button id="pw-kiosk-close" type="button" class="btn btn-sm btn-link p-1 text-decoration-none pw-kiosk-close-btn" title="Close panel (Esc)">
                         <i class="mdi mdi-close" style="font-size:1.2em;"></i>
                     </button>
@@ -529,7 +529,10 @@
 
 {% block javascript %}
 {{ block.super }}
-<script>window.PATHWAYS_CONFIG={{ pathways_config_json|safe }};</script>
+{{ pathways_config|json_script:"pathways-config" }}
+{{ map_init_config|json_script:"pathways-map-init" }}
+{# PATHWAYS_CONFIG must be set before the bundle: its modules read it at load time. #}
+<script>window.PATHWAYS_CONFIG=JSON.parse(document.getElementById('pathways-config').textContent);</script>
 <script src="{% static 'netbox_pathways/dist/pathways-map.min.js' %}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
@@ -564,13 +567,7 @@
             if (crumbs) crumbs.parentElement.style.display = 'none';
         }
         sizeMap();
-        initializePathwaysMap('pathways-map', {
-            center: [{{ map_center_lat }}, {{ map_center_lon }}],
-            zoom: {{ map_zoom }},
-            bounds: {{ map_bounds|default:"null" }},
-            kiosk: {{ kiosk|yesno:"true,false" }},
-            select: '{{ selected_feature|escapejs }}'
-        });
+        initializePathwaysMap('pathways-map', JSON.parse(document.getElementById('pathways-map-init').textContent));
         // Re-size after layout settles and on window resize
         setTimeout(sizeMap, 200);
         setTimeout(sizeMap, 500);

--- a/netbox_pathways/templates/netbox_pathways/route_planner.html
+++ b/netbox_pathways/templates/netbox_pathways/route_planner.html
@@ -455,14 +455,14 @@
 <link rel="stylesheet" href="{% static 'netbox_pathways/vendor/leaflet/leaflet.css' %}" />
 <link rel="stylesheet" href="{% static 'netbox_pathways/css/leaflet-theme.css' %}" />
 <script src="{% static 'netbox_pathways/vendor/leaflet/leaflet.js' %}"></script>
+{{ pathways_config|json_script:"pathways-config" }}
+{{ map_init_config|json_script:"pathways-map-init" }}
+{# PATHWAYS_CONFIG must be set before the bundle: its modules read it at load time. #}
+<script>window.PATHWAYS_CONFIG=JSON.parse(document.getElementById('pathways-config').textContent);</script>
 <script src="{% static 'netbox_pathways/dist/route-planner-map.min.js' %}"></script>
 <script>
 (function() {
-    // --- Config ---
-    window.PATHWAYS_CONFIG = {{ pathways_config_json|safe }};
-    var CENTER = [{{ map_center_lat }}, {{ map_center_lon }}];
-    var ZOOM = {{ map_zoom }};
-    var BOUNDS = {{ map_bounds|default:"null" }};
+    var MAP_INIT = JSON.parse(document.getElementById('pathways-map-init').textContent);
 
     // --- Viewport sizing ---
     function sizeMap() {
@@ -487,11 +487,7 @@
         sizeMap();
 
         try {
-            window.initializeRoutePlannerMap('pathways-map', {
-                center: CENTER,
-                zoom: ZOOM,
-                bounds: BOUNDS
-            });
+            window.initializeRoutePlannerMap('pathways-map', MAP_INIT);
         } catch (err) {
             console.error('[pathways] Map init failed:', err);
         }

--- a/netbox_pathways/views.py
+++ b/netbox_pathways/views.py
@@ -1207,8 +1207,6 @@ class RoutePlannerView(LoginRequiredMixin, View):
     """Route planner page with map + sidebar constraint builder."""
 
     def get(self, request):
-        import json
-
         from django.conf import settings
 
         cable_pk = request.GET.get("cable")
@@ -1265,29 +1263,25 @@ class RoutePlannerView(LoginRequiredMixin, View):
         default_lon = plugin_cfg.get("map_center_lon", -73.5673)
         default_zoom = plugin_cfg.get("map_zoom", 10)
 
+        center = [default_lat, default_lon]
+        bounds = None
+        if extent:
+            center = [(extent[1] + extent[3]) / 2, (extent[0] + extent[2]) / 2]
+            bounds = [[extent[1], extent[0]], [extent[3], extent[2]]]
+
         ctx = {
             "form": form,
             "cable": cable,
             "start_structure": start_structure,
             "end_structure": end_structure,
-            "pathways_config_json": json.dumps(pathways_config),
+            # Serialized with json_script in the template -- see MapView.get().
+            "pathways_config": pathways_config,
+            "map_init_config": {
+                "center": center,
+                "zoom": default_zoom,
+                "bounds": bounds,
+            },
         }
-
-        if extent:
-            ctx["map_center_lat"] = (extent[1] + extent[3]) / 2
-            ctx["map_center_lon"] = (extent[0] + extent[2]) / 2
-            ctx["map_zoom"] = default_zoom
-            ctx["map_bounds"] = json.dumps(
-                [
-                    [extent[1], extent[0]],
-                    [extent[3], extent[2]],
-                ]
-            )
-        else:
-            ctx["map_center_lat"] = default_lat
-            ctx["map_center_lon"] = default_lon
-            ctx["map_zoom"] = default_zoom
-            ctx["map_bounds"] = ""
 
         return render(request, "netbox_pathways/route_planner.html", ctx)
 
@@ -1784,8 +1778,6 @@ class MapView(LoginRequiredMixin, View):
         return None
 
     def get(self, request):
-        import json
-
         from django.conf import settings
 
         from .api.geo import _available_statuses
@@ -1813,61 +1805,44 @@ class MapView(LoginRequiredMixin, View):
         default_lon = plugin_cfg.get("map_center_lon", -73.5673)
         default_zoom = plugin_cfg.get("map_zoom", 10)
 
-        ctx = {
-            "pathways_config_json": json.dumps(pathways_config),
-        }
+        selected_feature = request.GET.get("select", "")
 
-        ctx["kiosk"] = request.GET.get("kiosk", "").lower() == "true"
-        ctx["selected_feature"] = request.GET.get("select", "")
+        # Viewport precedence: explicit lat/lon params, then the selected
+        # feature's bbox, then the data extent, then the configured default.
+        # `bounds` beats center/zoom client-side (fitBounds over setView), so
+        # only one of the two is ever populated.
+        center = [default_lat, default_lon]
+        zoom = default_zoom
+        bounds = None
 
         if request.GET.get("lat") or request.GET.get("lon"):
-            ctx["map_center_lat"] = self._safe_float(request.GET.get("lat"), default_lat)
-            ctx["map_center_lon"] = self._safe_float(request.GET.get("lon"), default_lon)
-            ctx["map_zoom"] = self._safe_int(request.GET.get("zoom"), default_zoom)
-            ctx["map_bounds"] = ""
-        elif ctx["selected_feature"]:
-            # Resolve bounds from the selected feature's geometry
-            sel_ext = self._resolve_feature_extent(ctx["selected_feature"])
-            if sel_ext:
-                ctx["map_center_lat"] = (sel_ext[1] + sel_ext[3]) / 2
-                ctx["map_center_lon"] = (sel_ext[0] + sel_ext[2]) / 2
-                ctx["map_zoom"] = 18  # fallback if fitBounds not used
-                ctx["map_bounds"] = json.dumps(
-                    [
-                        [sel_ext[1], sel_ext[0]],
-                        [sel_ext[3], sel_ext[2]],
-                    ]
-                )
-            elif extent:
-                ctx["map_center_lat"] = (extent[1] + extent[3]) / 2
-                ctx["map_center_lon"] = (extent[0] + extent[2]) / 2
-                ctx["map_zoom"] = default_zoom
-                ctx["map_bounds"] = json.dumps(
-                    [
-                        [extent[1], extent[0]],
-                        [extent[3], extent[2]],
-                    ]
-                )
-            else:
-                ctx["map_center_lat"] = default_lat
-                ctx["map_center_lon"] = default_lon
-                ctx["map_zoom"] = default_zoom
-                ctx["map_bounds"] = ""
-        elif extent:
-            ctx["map_center_lat"] = (extent[1] + extent[3]) / 2
-            ctx["map_center_lon"] = (extent[0] + extent[2]) / 2
-            ctx["map_zoom"] = default_zoom
-            ctx["map_bounds"] = json.dumps(
-                [
-                    [extent[1], extent[0]],
-                    [extent[3], extent[2]],
-                ]
-            )
+            center = [
+                self._safe_float(request.GET.get("lat"), default_lat),
+                self._safe_float(request.GET.get("lon"), default_lon),
+            ]
+            zoom = self._safe_int(request.GET.get("zoom"), default_zoom)
         else:
-            ctx["map_center_lat"] = default_lat
-            ctx["map_center_lon"] = default_lon
-            ctx["map_zoom"] = default_zoom
-            ctx["map_bounds"] = ""
+            box = self._resolve_feature_extent(selected_feature) if selected_feature else None
+            if box:
+                zoom = 18  # fallback if fitBounds is not used
+            else:
+                box = extent
+            if box:
+                center = [(box[1] + box[3]) / 2, (box[0] + box[2]) / 2]
+                bounds = [[box[1], box[0]], [box[3], box[2]]]
+
+        ctx = {
+            # Serialized with json_script in the template: locale-independent
+            # (see #93) and escaped against script-tag breakout.
+            "pathways_config": pathways_config,
+            "map_init_config": {
+                "center": center,
+                "zoom": zoom,
+                "bounds": bounds,
+                "kiosk": request.GET.get("kiosk", "").lower() == "true",
+                "select": selected_feature,
+            },
+        }
 
         return render(request, "netbox_pathways/map.html", ctx)
 

--- a/tests/test_map_view.py
+++ b/tests/test_map_view.py
@@ -1,5 +1,7 @@
 """Tests for MapView — kiosk param, URL params, parse_box, safe casts, data extent."""
 
+import json
+import re
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +16,17 @@ from netbox_pathways.views import MapView
 @pytest.fixture
 def factory():
     return RequestFactory()
+
+
+def parse_json_script(content, element_id):
+    """Extract and parse the payload of a Django `json_script` tag."""
+    match = re.search(
+        rf'<script id="{element_id}" type="application/json">(.*?)</script>',
+        content,
+        re.DOTALL,
+    )
+    assert match, f"no json_script tag with id={element_id!r} in the response"
+    return json.loads(match.group(1))
 
 
 @pytest.fixture
@@ -185,17 +198,6 @@ class TestMapViewGet:
         content = response.content.decode()
         assert "pathways-map-wrapper pw-kiosk" in content
 
-    def test_lat_lon_zoom_params(self, factory):
-        response = self._get(factory, "lat=48.8&lon=2.3&zoom=15")
-        content = response.content.decode()
-        assert "48.8" in content
-        assert "2.3" in content
-        assert "15" in content
-
-    def test_lat_lon_without_zoom_uses_default(self, factory):
-        response = self._get(factory, "lat=48.8&lon=2.3")
-        assert response.status_code == 200
-
     def test_config_carries_status_choices(self, factory):
         """The inactive-set panel must not depend on an /info round-trip
         (skipped entirely at high zoom), so statuses ship with the page."""
@@ -204,33 +206,140 @@ class TestMapViewGet:
         assert '"statuses"' in content
         assert '"retired"' in content
 
-    def test_kiosk_js_config(self, factory):
-        """The JS init config should contain kiosk: true when param is set."""
-        response = self._get(factory, "kiosk=true")
-        content = response.content.decode()
-        assert "kiosk: true" in content
-
-    def test_no_kiosk_js_config(self, factory):
-        """The JS init config should contain kiosk: false when param is not set."""
-        response = self._get(factory, "")
-        content = response.content.decode()
-        assert "kiosk: false" in content
-
     def test_invalid_lat_uses_default(self, factory):
         response = self._get(factory, "lat=notanumber&lon=2.3")
         assert response.status_code == 200
 
-    def test_extent_used_when_no_params(self, factory):
-        """When no lat/lon params, _data_extent result is used."""
-        request = factory.get("/plugins/pathways/map/")
-        from django.contrib.auth.models import AnonymousUser
 
-        request.user = AnonymousUser()
-        view = MapView()
-        extent = (-73.6, 45.4, -73.5, 45.6)
-        with patch.object(view, "_data_extent", return_value=extent):
-            response = view.get(request)
-        content = response.content.decode()
-        # Center should be midpoint of extent
-        expected_lat = (45.4 + 45.6) / 2
-        assert str(expected_lat) in content
+# ---------------------------------------------------------------------------
+# MapView.get — client config payload
+# ---------------------------------------------------------------------------
+
+
+def render_map(factory, query_string="", extent=None, feature_extent=None):
+    """Render MapView.get() and return the response body.
+
+    `extent` stands in for the trimmed data extent; `feature_extent` for the
+    bbox a `?select=` value resolves to. Both are patched to keep the test
+    off the database.
+    """
+    from django.contrib.auth.models import AnonymousUser
+
+    request = factory.get(f"/plugins/pathways/map/?{query_string}")
+    request.user = AnonymousUser()
+    view = MapView()
+    with (
+        patch.object(view, "_data_extent", return_value=extent),
+        patch.object(MapView, "_resolve_feature_extent", return_value=feature_extent),
+    ):
+        return view.get(request).content.decode()
+
+
+@pytest.mark.django_db
+class TestMapConfigPayload:
+    """The client config must survive any active locale and honour the
+    documented precedence: lat/lon params > ?select= > data extent > defaults.
+    """
+
+    def test_center_is_json_not_localized(self, factory, settings):
+        """Regression for #93: under a locale that formats decimals with a
+        comma, template interpolation rendered `center: [52,42, 10,78]` --
+        four array items -- and Leaflet threw on `t.lat`. The config must be
+        serialized as JSON, which is locale-independent.
+        """
+        from django.utils import translation
+
+        settings.PLUGINS_CONFIG = {
+            **settings.PLUGINS_CONFIG,
+            "netbox_pathways": {
+                **settings.PLUGINS_CONFIG.get("netbox_pathways", {}),
+                "map_center_lat": 52.42,
+                "map_center_lon": 10.78,
+            },
+        }
+
+        with translation.override("de"):
+            content = render_map(factory)
+
+        assert parse_json_script(content, "pathways-map-init")["center"] == [52.42, 10.78]
+        # No comma-formatted decimal may reach the page at all.
+        assert "52,42" not in content
+
+    def test_lat_lon_params_win_over_data_extent(self, factory):
+        """An explicit viewport must not be overridden by the data extent:
+        `bounds` would otherwise reach Leaflet and fitBounds beats setView.
+        """
+        content = render_map(
+            factory,
+            "lat=48.8&lon=2.3&zoom=15",
+            extent=(-73.6, 45.4, -73.5, 45.6),
+        )
+
+        config = parse_json_script(content, "pathways-map-init")
+        assert config["center"] == [48.8, 2.3]
+        assert config["zoom"] == 15
+        assert config["bounds"] is None
+
+    def test_lat_lon_without_zoom_falls_back_to_configured_zoom(self, factory, settings):
+        settings.PLUGINS_CONFIG = {
+            **settings.PLUGINS_CONFIG,
+            "netbox_pathways": {
+                **settings.PLUGINS_CONFIG.get("netbox_pathways", {}),
+                "map_zoom": 12,
+            },
+        }
+
+        content = render_map(factory, "lat=48.8&lon=2.3")
+
+        assert parse_json_script(content, "pathways-map-init")["zoom"] == 12
+
+    def test_selected_feature_reaches_client(self, factory):
+        """The sidebar auto-opens the selected feature from this value."""
+        content = render_map(
+            factory,
+            "select=structure-123",
+            feature_extent=(-73.6, 45.4, -73.5, 45.6),
+        )
+
+        config = parse_json_script(content, "pathways-map-init")
+        assert config["select"] == "structure-123"
+        assert config["bounds"] == [[45.4, -73.6], [45.6, -73.5]]
+        # Close zoom for a single feature, used only if fitBounds is skipped.
+        assert config["zoom"] == 18
+
+    def test_selected_feature_bounds_win_over_data_extent(self, factory):
+        content = render_map(
+            factory,
+            "select=structure-123",
+            extent=(-10.0, -10.0, 10.0, 10.0),
+            feature_extent=(-73.6, 45.4, -73.5, 45.6),
+        )
+
+        assert parse_json_script(content, "pathways-map-init")["bounds"] == [
+            [45.4, -73.6],
+            [45.6, -73.5],
+        ]
+
+    def test_unresolvable_selection_falls_back_to_data_extent(self, factory):
+        content = render_map(
+            factory,
+            "select=structure-999",
+            extent=(-73.6, 45.4, -73.5, 45.6),
+            feature_extent=None,
+        )
+
+        assert parse_json_script(content, "pathways-map-init")["bounds"] == [
+            [45.4, -73.6],
+            [45.6, -73.5],
+        ]
+
+    def test_data_extent_used_when_no_params(self, factory):
+        content = render_map(factory, extent=(-73.6, 45.4, -73.5, 45.6))
+
+        config = parse_json_script(content, "pathways-map-init")
+        assert config["center"] == [45.5, -73.55]
+        assert config["bounds"] == [[45.4, -73.6], [45.6, -73.5]]
+
+    def test_kiosk_flag_in_config(self, factory):
+        assert parse_json_script(render_map(factory, "kiosk=true"), "pathways-map-init")["kiosk"] is True
+        assert parse_json_script(render_map(factory), "pathways-map-init")["kiosk"] is False

--- a/tests/test_route_planner_views.py
+++ b/tests/test_route_planner_views.py
@@ -9,12 +9,14 @@ from django.test import RequestFactory
 from netbox_pathways.geo import get_srid
 from netbox_pathways.models import Pathway, PlannedRoute, Structure
 from netbox_pathways.views import (
+    MapView,
     RoutePlannerConstraintView,
     RoutePlannerFindView,
     RoutePlannerSaveView,
     RoutePlannerView,
 )
 from tests.conftest import build_cable_with_terminations
+from tests.test_map_view import parse_json_script
 
 SRID = get_srid()
 
@@ -257,3 +259,51 @@ class TestRoutePlannerConstraintView:
         # Rendered widget must include the api-select hook so the frontend
         # lazy-loads options instead of materializing all rows.
         assert "api-select" in body
+
+
+# ---------------------------------------------------------------------------
+# RoutePlannerView.get — client config payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRoutePlannerMapConfig:
+    def _render(self, factory, admin_user, extent=None):
+        request = factory.get("/pathways/route-planner/")
+        request.user = admin_user
+        with patch.object(MapView, "_data_extent", return_value=extent):
+            return RoutePlannerView().get(request).content.decode()
+
+    def test_window_config_carries_api_base_and_layers(self, factory, admin_user):
+        """The planner reads apiBase and baseLayers off window.PATHWAYS_CONFIG;
+        an empty payload leaves the map without tiles or a data source.
+        """
+        config = parse_json_script(self._render(factory, admin_user), "pathways-config")
+
+        assert config["apiBase"]
+        assert "baseLayers" in config
+
+    def test_center_is_json_not_localized(self, factory, admin_user, settings):
+        """Regression for #93 on the planner map -- see the MapView test."""
+        from django.utils import translation
+
+        settings.PLUGINS_CONFIG = {
+            **settings.PLUGINS_CONFIG,
+            "netbox_pathways": {
+                **settings.PLUGINS_CONFIG.get("netbox_pathways", {}),
+                "map_center_lat": 52.42,
+                "map_center_lon": 10.78,
+            },
+        }
+
+        with translation.override("de"):
+            content = self._render(factory, admin_user)
+
+        assert parse_json_script(content, "pathways-map-init")["center"] == [52.42, 10.78]
+
+    def test_data_extent_becomes_bounds(self, factory, admin_user):
+        content = self._render(factory, admin_user, extent=(-73.6, 45.4, -73.5, 45.6))
+
+        config = parse_json_script(content, "pathways-map-init")
+        assert config["center"] == [45.5, -73.55]
+        assert config["bounds"] == [[45.4, -73.6], [45.6, -73.5]]


### PR DESCRIPTION
## Summary

- The map and route planner pages failed to load for any user on a locale that formats decimals with a comma: Django localized the center floats during template rendering, so the page received `center: [52,42, 10,78]` -- a four-element array -- and Leaflet threw `TypeError: null is not an object (evaluating 't.lat')` on a blank map.
- Both views now build the client config in Python; the templates emit it with Django's `json_script`, which is locale-independent and escapes the payload against script-tag breakout. This also removes the `|safe` and `escapejs` hand-escaping.
- Payload keys are unchanged (`center`, `zoom`, `bounds`, `kiosk`, `select`), so no TypeScript change and no bundle rebuild -- `dist/` is untouched.

Reported and diagnosed by @JulianJacobi in #93, who traced the stack trace to the exact generated line. Supersedes #94, which took the same approach but dropped the `?lat=/?lon=` and `?select=` handling; see the discussion there.

## Changes

- `netbox_pathways/views.py`: `MapView.get()` and `RoutePlannerView.get()` build `pathways_config` and `map_init_config` dicts instead of pre-rendered JSON strings and loose float context keys. MapView's four-way viewport branch collapses into one block that preserves the existing precedence -- explicit lat/lon params, then the `?select=` feature bbox, then the data extent, then the configured default -- including the `zoom = 18` fallback for a resolved feature.
- `templates/netbox_pathways/map.html`: emit both configs via `json_script`; init the map from the parsed payload; kiosk conditionals read `map_init_config.kiosk`.
- `templates/netbox_pathways/route_planner.html`: same, and assign `window.PATHWAYS_CONFIG` *before* the bundle `<script src>` -- `map-core` and `data-layers` capture it at module load, so the previous later assignment left them on defaults.
- `tests/test_map_view.py`: new `TestMapConfigPayload` covering the locale regression and the full viewport precedence chain; removed four tests that asserted on the old inline-JS syntax (`kiosk: true`, bare `48.8` in the body).
- `tests/test_route_planner_views.py`: new `TestRoutePlannerMapConfig` -- asserts the window config actually carries `apiBase`/`baseLayers` (fails if the context key and template variable ever drift apart), plus the locale regression on the planner map.
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally -- 552 passed, coverage 75.65% (threshold 65%)
- [x] New/changed behavior covered by tests
- [x] Migration applied cleanly (if schema changed) -- n/a, no schema change
- [x] Docs updated (README, CHANGELOG, zensical pages) if user-visible -- CHANGELOG only; the `map_center_lat`/`map_center_lon`/`map_zoom` plugin settings are unchanged, only internal context keys moved

The regression test was confirmed red before the fix. On unmodified `main`, rendering the map view under `translation.override("de")` with a configured center of `52.42, 10.78` produces:

```
center: [52,42, 10,78]
```

`manage.py check` reports no issues.

## Related

Fixes: #93
Refs: #94
