### PR TITLE
fix(templates): extend generic/object.html in the cable route tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Route tab on a Cable raised `TemplateDoesNotExist` on NetBox 4.6.**
+  `cable_route_tab.html` extended `dcim/cable.html`, which NetBox 4.6 removed
+  when the cable detail view moved to the layout system, so opening the Route
+  tab of any cable returned a server error. The template now extends
+  `generic/object.html`, like every other detail template in this plugin, and
+  renders identically on 4.5 and 4.6. Contributed by @JulianJacobi. Fixes #73.
+
 - **The map and route planner failed to load for users on a non-English
   locale.** Django localizes numbers when a template renders them, so under
   a language that uses a comma as the decimal separator (German, French,

--- a/netbox_pathways/templates/netbox_pathways/cable_route_tab.html
+++ b/netbox_pathways/templates/netbox_pathways/cable_route_tab.html
@@ -1,4 +1,4 @@
-{% extends 'dcim/cable.html' %}
+{% extends 'generic/object.html' %}
 
 {% block content %}
 <style>


### PR DESCRIPTION
## Summary

- The Route tab on a Cable raised `TemplateDoesNotExist` on NetBox 4.6: `cable_route_tab.html` extended `dcim/cable.html`, which 4.6 removed when the cable detail view moved to the layout system.
- The template now extends `generic/object.html`, matching every other detail template in this plugin, and renders identically on NetBox 4.5 and 4.6.

## Changes

- `netbox_pathways/templates/netbox_pathways/cable_route_tab.html`: extend `generic/object.html` instead of the removed `dcim/cable.html`.
- `CHANGELOG.md`: entry under `[Unreleased]` / `Fixed`.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally
- [ ] New/changed behavior covered by tests -- **intentionally not covered.** The only assertion available is that the base template resolves, which tests NetBox's template inventory rather than any plugin logic. Verified manually instead: the Route tab renders on NetBox 4.6.3, and reverting the one-line change reproduces `TemplateDoesNotExist: dcim/cable.html`.
- [x] Migration applied cleanly (if schema changed) -- n/a, no schema change
- [x] Docs updated (README, CHANGELOG, zensical pages) if user-visible -- CHANGELOG only; no documented behavior changes

## Related

Fixes #73
