### PR TITLE
feat(innerduct): pick color from the NetBox palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   working. Color is no longer indexed for global search: it holds a hex
   code now, which nobody searches for.
 
+- **The innerduct list filter now renders its size and position fields.**
+  `InnerductFilterSet` accepted both parameters already, but the filter
+  form omitted them, so they could only be reached by editing the URL.
+
 - **The base-layer selector now sits bottom-right on every map.** The
   full-page map already put it there; the geometry edit widget and the
   detail-page mini maps had it top-right. Refs #75.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Innerduct color is now picked from NetBox's color palette** instead of
+  typed as free text. The edit, bulk-edit and list-filter forms use the core
+  color widget, and innerduct tables -- including the one on a conduit's
+  detail page -- render the value as a swatch rather than a color name.
+  Refs #79.
+
+  Migration `0022_innerduct_color_hex` converts the existing free-text
+  values: names in the palette become their hex code, and `slate`,
+  `violet`, `magenta`, `silver`, `natural`, `clear` and US "gray" spellings
+  map onto the nearest palette entry. **A value matching none of these is
+  cleared**, because the column narrows from 50 characters to 6; the
+  migration prints every value it drops, so check that list before
+  migrating a database with hand-written colors. Reversing the migration
+  restores palette names.
+
+  CSV import still accepts a color name (`Blue`) or a hex code (`2196f3`)
+  and rejects anything it cannot resolve, so existing import files keep
+  working. Color is no longer indexed for global search: it holds a hex
+  code now, which nobody searches for.
+
 - **The base-layer selector now sits bottom-right on every map.** The
   full-page map already put it there; the geometry edit widget and the
   detail-page mini maps had it top-right. Refs #75.

--- a/docs/user-guide/pathways.md
+++ b/docs/user-guide/pathways.md
@@ -52,8 +52,14 @@ A smaller duct installed inside a parent conduit to subdivide capacity.
 |-------|-------------|
 | Parent Conduit | The conduit this innerduct is inside |
 | Size | Innerduct size (e.g., `1.25"`, `32mm`) |
-| Color | Innerduct color for identification |
+| Color | Innerduct color, chosen from NetBox's color palette |
 | Position | Position within the parent conduit |
+
+Color is picked from NetBox's standard palette, the same widget used for rack
+roles and cables, and renders as a swatch in innerduct tables and on the
+parent conduit's detail page. CSV import also accepts a color name (`Blue`) or
+a bare hex code (`2196f3`); `slate` and `violet` from the telecom 12-color code
+map onto the nearest palette entries.
 
 Innerducts inherit start and end endpoints (structures or locations) from their parent conduit if not explicitly set.
 

--- a/netbox_pathways/colors.py
+++ b/netbox_pathways/colors.py
@@ -1,0 +1,61 @@
+"""Resolve color names to the hex codes NetBox's core color palette uses.
+
+Innerduct colors were free text until issue #79 and users typed names by
+hand ("blue", "slate"). The field now stores a 6-digit hex code, so the
+0022 data migration and the CSV import form both need to translate those
+names -- and keep accepting them, since operators paste the same
+spreadsheets year after year.
+"""
+
+import re
+
+from netbox.choices import ColorChoices
+
+# Names the core palette does not carry. "Slate" and "violet" are two of the
+# telecom 12-color code; the rest are spellings seen in imported plant data.
+_SYNONYMS = {
+    "slate": ColorChoices.COLOR_DARK_GREY,
+    "violet": ColorChoices.COLOR_PURPLE,
+    "magenta": ColorChoices.COLOR_FUCHSIA,
+    "silver": ColorChoices.COLOR_LIGHT_GREY,
+    "natural": ColorChoices.COLOR_WHITE,
+    "clear": ColorChoices.COLOR_WHITE,
+}
+
+# Labels first, so a deployment that extends ColorChoices via FIELD_CHOICES
+# gets its additions; then the COLOR_* constant names, which stay English
+# even where the labels are translated.
+_HEX_BY_NAME = {str(label).lower(): value for value, label in ColorChoices.CHOICES}
+_HEX_BY_NAME.update(
+    {
+        name.removeprefix("COLOR_").replace("_", " ").lower(): value
+        for name, value in vars(ColorChoices).items()
+        if name.startswith("COLOR_")
+    }
+)
+# The palette labels all spell it "grey".
+_HEX_BY_NAME.update({name.replace("grey", "gray"): value for name, value in _HEX_BY_NAME.items() if "grey" in name})
+_HEX_BY_NAME.update(_SYNONYMS)
+
+_HEX_RE = re.compile(r"^#?([0-9a-f]{3}|[0-9a-f]{6})$")
+
+
+def color_to_hex(value):
+    """Return `value` as a 6-digit lowercase hex code, without the leading '#'.
+
+    Blank input returns blank. A value matching neither a known name nor a
+    hex code returns None, leaving the caller to choose between dropping it
+    (the migration) and reporting an error (the import form).
+    """
+    if not value:
+        return ""
+    text = str(value).strip().lower()
+    if not text:
+        return ""
+    if named := _HEX_BY_NAME.get(text):
+        return named
+    match = _HEX_RE.match(text)
+    if not match:
+        return None
+    digits = match.group(1)
+    return "".join(digit * 2 for digit in digits) if len(digits) == 3 else digits

--- a/netbox_pathways/filterforms.py
+++ b/netbox_pathways/filterforms.py
@@ -222,7 +222,7 @@ class InnerductFilterForm(NetBoxModelFilterSetForm):
     model = Innerduct
     fieldsets = (
         FieldSet("q", "filter_id", "tag"),
-        FieldSet("status", "parent_conduit_id", "color", name="Attributes"),
+        FieldSet("status", "parent_conduit_id", "size", "color", "position", name="Attributes"),
     )
     status = forms.MultipleChoiceField(choices=PathwayStatusChoices, required=False)
     parent_conduit_id = DynamicModelMultipleChoiceField(
@@ -230,8 +230,10 @@ class InnerductFilterForm(NetBoxModelFilterSetForm):
         required=False,
         label="Parent Conduit",
     )
+    size = forms.CharField(required=False)
     # The picker is the only practical way to filter on a stored hex code.
     color = ColorField(required=False)
+    position = forms.CharField(required=False)
     tag = TagFilterField(model)
 
 

--- a/netbox_pathways/filterforms.py
+++ b/netbox_pathways/filterforms.py
@@ -5,7 +5,7 @@ from dcim.models import Cable, Location, Site
 from django import forms
 from netbox.forms import NetBoxModelFilterSetForm
 from tenancy.models import Tenant
-from utilities.forms.fields import DynamicModelMultipleChoiceField, TagFilterField
+from utilities.forms.fields import ColorField, DynamicModelMultipleChoiceField, TagFilterField
 from utilities.forms.rendering import FieldSet
 
 from .choices import (
@@ -222,7 +222,7 @@ class InnerductFilterForm(NetBoxModelFilterSetForm):
     model = Innerduct
     fieldsets = (
         FieldSet("q", "filter_id", "tag"),
-        FieldSet("status", "parent_conduit_id", name="Attributes"),
+        FieldSet("status", "parent_conduit_id", "color", name="Attributes"),
     )
     status = forms.MultipleChoiceField(choices=PathwayStatusChoices, required=False)
     parent_conduit_id = DynamicModelMultipleChoiceField(
@@ -230,6 +230,8 @@ class InnerductFilterForm(NetBoxModelFilterSetForm):
         required=False,
         label="Parent Conduit",
     )
+    # The picker is the only practical way to filter on a stored hex code.
+    color = ColorField(required=False)
     tag = TagFilterField(model)
 
 

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -9,6 +9,7 @@ from django.utils.safestring import mark_safe
 from netbox.forms import NetBoxModelBulkEditForm, NetBoxModelForm, NetBoxModelImportForm
 from tenancy.models import Tenant
 from utilities.forms.fields import (
+    ColorField,
     CSVChoiceField,
     CSVModelChoiceField,
     DynamicModelChoiceField,
@@ -27,6 +28,7 @@ from .choices import (
     StructureStatusChoices,
     StructureTypeChoices,
 )
+from .colors import color_to_hex
 from .coord_parser import ForgivingGeometryField
 from .geo import get_srid, to_leaflet
 from .models import (
@@ -867,7 +869,7 @@ class InnerductBulkEditForm(NetBoxModelBulkEditForm):
         selector=True,
     )
     status = forms.ChoiceField(choices=PathwayStatusChoices, required=False)
-    color = forms.CharField(max_length=50, required=False)
+    color = ColorField(required=False)
     size = forms.CharField(max_length=50, required=False)
     installed_by = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False, selector=True)
     commissioned_date = forms.DateField(required=False)
@@ -970,12 +972,27 @@ class InnerductImportForm(PathwayPathFallbackMixin, NetBoxModelImportForm):
     end_location = _csv_location_field("Ending")
     tenant = _csv_tenant_field("Owner tenant name")
     installed_by = _csv_tenant_field("Installer tenant name")
+    color = forms.CharField(
+        required=False,
+        max_length=16,
+        help_text='Color name (e.g. "Blue") or hex code (e.g. "2196f3")',
+    )
     path = ForgivingGeometryField(
         required=False,
         srid=get_srid(),
         geom_type="LINESTRING",
         help_text=_IMPORT_GEOMETRY_HELP,
     )
+
+    def clean_color(self):
+        # Colors were free text before issue #79, so imports that still name
+        # them keep working; anything unrecognized is an error rather than a
+        # silently blank field.
+        color = self.cleaned_data.get("color")
+        hex_code = color_to_hex(color)
+        if hex_code is None:
+            raise forms.ValidationError(f'"{color}" is not a known color name or hex code')
+        return hex_code
 
     class Meta:
         model = Innerduct

--- a/netbox_pathways/graphql/types.py
+++ b/netbox_pathways/graphql/types.py
@@ -95,6 +95,9 @@ class DirectBuriedType(NetBoxObjectType):
 class InnerductType(NetBoxObjectType):
     """GraphQL type for Innerduct."""
 
+    # ColorField has no strawberry mapping; core declares it the same way.
+    color: str
+
 
 @strawberry_django.type(ConduitJunction, fields="__all__")
 class ConduitJunctionType(NetBoxObjectType):

--- a/netbox_pathways/management/commands/generate_sample_data.py
+++ b/netbox_pathways/management/commands/generate_sample_data.py
@@ -10,6 +10,7 @@ import random
 from dcim.models import Cable, Location, Site
 from django.contrib.gis.geos import LineString, Point
 from django.core.management.base import BaseCommand
+from netbox.choices import ColorChoices
 from tenancy.models import Tenant
 
 from netbox_pathways.geo import get_srid
@@ -57,7 +58,15 @@ AERIAL_TYPES = ["messenger", "self_support", "lashed", "wrapped", "adss"]
 BANK_CONFIGS = ["1x2", "1x3", "1x4", "2x2", "2x3", "3x3", "3x4", "custom"]
 ENCASEMENT_TYPES = ["concrete", "direct_buried", "bore", "bridge_attachment", "tunnel"]
 INNERDUCT_SIZES = ['1.25"', '1"', "32mm", "25mm", '1.5"']
-INNERDUCT_COLORS = ["orange", "blue", "green", "red", "yellow", "white", "black"]
+INNERDUCT_COLORS = [
+    ColorChoices.COLOR_ORANGE,
+    ColorChoices.COLOR_BLUE,
+    ColorChoices.COLOR_GREEN,
+    ColorChoices.COLOR_RED,
+    ColorChoices.COLOR_YELLOW,
+    ColorChoices.COLOR_WHITE,
+    ColorChoices.COLOR_BLACK,
+]
 
 CITY_NAMES = [
     "Montreal",

--- a/netbox_pathways/migrations/0022_innerduct_color_hex.py
+++ b/netbox_pathways/migrations/0022_innerduct_color_hex.py
@@ -1,0 +1,62 @@
+"""Store Innerduct.color as a palette hex code instead of free text (issue #79).
+
+The old field accepted any 50-character string, so existing rows hold color
+names. They are translated to the matching hex code before the column is
+narrowed to six characters; anything that matches no known color is cleared
+and reported, since it cannot survive the narrower column.
+"""
+
+import utilities.fields
+from django.db import migrations
+from netbox.choices import ColorChoices
+
+# netbox_pathways.colors is a pure name-to-hex lookup with no model imports.
+# It is safe to call from a migration: on a fresh database this data pass is
+# a no-op, so later edits to the lookup cannot change what already ran.
+from netbox_pathways.colors import color_to_hex
+
+_NAME_BY_HEX = {value: str(label) for value, label in ColorChoices.CHOICES}
+
+
+def color_names_to_hex(apps, schema_editor):
+    Innerduct = apps.get_model("netbox_pathways", "Innerduct")
+    existing = set(Innerduct.objects.exclude(color="").values_list("color", flat=True))
+    dropped = []
+    for color in existing:
+        hex_code = color_to_hex(color)
+        if hex_code is None:
+            dropped.append(color)
+            hex_code = ""
+        if hex_code != color:
+            Innerduct.objects.filter(color=color).update(color=hex_code)
+    if dropped:
+        print(
+            f"\n  netbox_pathways: cleared {len(dropped)} unrecognized innerduct "
+            f"color(s): {', '.join(sorted(dropped))}"
+        )
+
+
+def hex_to_color_names(apps, schema_editor):
+    """Restore palette names; hex codes outside the palette are left as-is."""
+    Innerduct = apps.get_model("netbox_pathways", "Innerduct")
+    for hex_code, name in _NAME_BY_HEX.items():
+        Innerduct.objects.filter(color=hex_code).update(color=name.lower())
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_pathways", "0021_structure_geometry_and_location"),
+    ]
+
+    operations = [
+        migrations.RunPython(color_names_to_hex, hex_to_color_names),
+        migrations.AlterField(
+            model_name="innerduct",
+            name="color",
+            field=utilities.fields.ColorField(
+                blank=True,
+                help_text="Innerduct color for identification",
+                max_length=6,
+            ),
+        ),
+    ]

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -8,6 +8,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.urls import reverse
 from netbox.models import NetBoxModel
 from tenancy.models import Tenant
+from utilities.fields import ColorField
 from utilities.querysets import RestrictedQuerySet
 
 from .choices import (
@@ -711,7 +712,7 @@ class Innerduct(Pathway):
         return False
 
     size = models.CharField(max_length=50, help_text='Innerduct size (e.g., 1.25", 32mm)')
-    color = models.CharField(max_length=50, blank=True, help_text="Innerduct color for identification")
+    color = ColorField(blank=True, help_text="Innerduct color for identification")
     position = models.CharField(max_length=50, blank=True, help_text="Position within parent conduit")
 
     class Meta:

--- a/netbox_pathways/search.py
+++ b/netbox_pathways/search.py
@@ -56,11 +56,12 @@ class InnerductIndex(SearchIndex):
     fields = (
         ("label", 100),
         ("size", 200),
-        ("color", 300),
         ("position", 300),
         ("comments", 5000),
     )
-    display_attrs = ("status", "parent_conduit", "size", "color")
+    # Color is a hex code since issue #79 -- not worth indexing or displaying
+    # as text.
+    display_attrs = ("status", "parent_conduit", "size")
 
 
 @register_search

--- a/netbox_pathways/tables.py
+++ b/netbox_pathways/tables.py
@@ -283,6 +283,7 @@ class InnerductTable(NetBoxTable):
     )
     status = columns.ChoiceFieldColumn()
     parent_conduit = tables.Column(linkify=True)
+    color = columns.ColorColumn()
     installed_by = tables.Column(linkify=True, verbose_name="Installed by")
     cables_routed = tables.Column(verbose_name="Cables", orderable=True)
     in_use = columns.BooleanColumn(verbose_name="In Use", orderable=True)

--- a/netbox_pathways/ui/panels.py
+++ b/netbox_pathways/ui/panels.py
@@ -130,7 +130,7 @@ class InnerductPanel(ObjectAttributesPanel):
     status = attrs.ChoiceAttr("status", label=_("Status"))
     parent_conduit = attrs.RelatedObjectAttr("parent_conduit", linkify=True, label=_("Parent conduit"))
     size = attrs.TextAttr("size", label=_("Size"))
-    color = attrs.TextAttr("color", label=_("Color"))
+    color = attrs.ColorAttr("color", label=_("Color"))
     position = attrs.TextAttr("position", label=_("Position"))
     length = attrs.NumericAttr("length", label=_("Length (m, as-built)"))
     geo_length = attrs.NumericAttr("geo_length", label=_("Geo length (m, drawn)"))

--- a/tests/test_innerduct_color.py
+++ b/tests/test_innerduct_color.py
@@ -83,6 +83,11 @@ class TestInnerductColorWiring:
     def test_filter_form_uses_the_core_color_widget(self, db):
         assert isinstance(filterforms.InnerductFilterForm().fields["color"].widget, ColorSelect)
 
+    def test_filter_form_exposes_every_innerduct_attribute_filter(self, db):
+        """The filterset has always accepted these; the form omitted them."""
+        rendered = {item for fieldset in filterforms.InnerductFilterForm.fieldsets for item in fieldset.items}
+        assert {"size", "color", "position"} <= rendered
+
     def test_table_renders_color_as_a_swatch(self):
         assert isinstance(tables.InnerductTable.base_columns["color"], columns.ColorColumn)
 

--- a/tests/test_innerduct_color.py
+++ b/tests/test_innerduct_color.py
@@ -1,0 +1,141 @@
+"""Tests for issue #79: Innerduct.color as a NetBox color choice.
+
+The field used to be free text, so users typed color names by hand. It now
+stores a 6-digit hex from NetBox's core palette and renders through the core
+color widget and column. The name-to-hex helper is what keeps the legacy
+values (and legacy CSV imports) working.
+"""
+
+import importlib
+
+import pytest
+from django.apps import apps as global_apps
+from django.contrib.gis.geos import LineString, Point
+from netbox.choices import ColorChoices
+from netbox.tables import columns
+from utilities.forms.widgets import ColorSelect
+
+from netbox_pathways import filterforms, forms, models, tables
+from netbox_pathways.colors import color_to_hex
+from netbox_pathways.geo import get_srid
+
+SRID = get_srid()
+
+
+class TestColorToHex:
+    """Legacy free-text values map onto the core palette where they can."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("blue", ColorChoices.COLOR_BLUE),
+            ("Blue", ColorChoices.COLOR_BLUE),
+            ("  ORANGE  ", ColorChoices.COLOR_ORANGE),
+            ("dark green", ColorChoices.COLOR_DARK_GREEN),
+            ("light grey", ColorChoices.COLOR_LIGHT_GREY),
+        ],
+    )
+    def test_palette_labels_resolve(self, value, expected):
+        assert color_to_hex(value) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            # The telecom 12-color code has two names the palette lacks.
+            ("slate", ColorChoices.COLOR_DARK_GREY),
+            ("violet", ColorChoices.COLOR_PURPLE),
+            # US spelling, which the palette labels do not use.
+            ("gray", ColorChoices.COLOR_GREY),
+            ("dark gray", ColorChoices.COLOR_DARK_GREY),
+        ],
+    )
+    def test_synonyms_resolve(self, value, expected):
+        assert color_to_hex(value) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("ff9800", "ff9800"),
+            ("#FF9800", "ff9800"),
+            ("f00", "ff0000"),
+        ],
+    )
+    def test_hex_values_pass_through_normalized(self, value, expected):
+        assert color_to_hex(value) == expected
+
+    def test_blank_stays_blank(self):
+        assert color_to_hex("") == ""
+        assert color_to_hex(None) == ""
+
+    @pytest.mark.parametrize("value", ["mauve", "duct #4", "ggg", "12345"])
+    def test_unrecognized_values_are_none(self, value):
+        """None, not blank -- callers decide between dropping and rejecting."""
+        assert color_to_hex(value) is None
+
+
+class TestInnerductColorWiring:
+    def test_edit_form_uses_the_core_color_widget(self, db):
+        assert isinstance(forms.InnerductForm().fields["color"].widget, ColorSelect)
+
+    def test_bulk_edit_form_uses_the_core_color_widget(self, db):
+        assert isinstance(forms.InnerductBulkEditForm().fields["color"].widget, ColorSelect)
+
+    def test_filter_form_uses_the_core_color_widget(self, db):
+        assert isinstance(filterforms.InnerductFilterForm().fields["color"].widget, ColorSelect)
+
+    def test_table_renders_color_as_a_swatch(self):
+        assert isinstance(tables.InnerductTable.base_columns["color"], columns.ColorColumn)
+
+
+class TestInnerductImportColor:
+    """CSV import keeps accepting the color names it accepted before."""
+
+    def test_a_color_name_is_stored_as_hex(self, db):
+        form = forms.InnerductImportForm(data={"color": "Blue"})
+        form.is_valid()  # other required fields are missing; only color matters here
+        assert form.cleaned_data["color"] == ColorChoices.COLOR_BLUE
+
+    def test_a_hex_code_is_accepted(self, db):
+        form = forms.InnerductImportForm(data={"color": "2196f3"})
+        form.is_valid()
+        assert form.cleaned_data["color"] == ColorChoices.COLOR_BLUE
+
+    def test_an_unrecognized_color_is_rejected(self, db):
+        form = forms.InnerductImportForm(data={"color": "mauve"})
+        form.is_valid()
+        assert "color" in form.errors
+
+
+class TestColorDataMigration:
+    """Migration 0022 rewrites the free-text colors already in the table."""
+
+    def test_names_become_hex_and_unknowns_are_cleared(self, db, capsys):
+        conduit = models.Conduit.objects.create(
+            label="color-migration-conduit",
+            path=LineString((0, 0), (100, 0), srid=SRID),
+            start_structure=models.Structure.objects.create(
+                name="color-migration-start",
+                geometry=Point(0, 0, srid=SRID),
+            ),
+            end_structure=models.Structure.objects.create(
+                name="color-migration-end",
+                geometry=Point(100, 0, srid=SRID),
+            ),
+        )
+        # Values must fit the post-migration column, so keep them short.
+        for index, color in enumerate(["orange", "blue", "mauve"]):
+            models.Innerduct.objects.create(
+                label=f"color-migration-{index}",
+                parent_conduit=conduit,
+                size="32mm",
+                color=color,
+            )
+
+        migration = importlib.import_module("netbox_pathways.migrations.0022_innerduct_color_hex")
+        migration.color_names_to_hex(global_apps, None)
+
+        colors = dict(models.Innerduct.objects.values_list("label", "color"))
+        assert colors["color-migration-0"] == ColorChoices.COLOR_ORANGE
+        assert colors["color-migration-1"] == ColorChoices.COLOR_BLUE
+        assert colors["color-migration-2"] == ""
+        assert "mauve" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- `Innerduct.color` was a 50-character free-text field, so operators typed
  color names by hand and every table and detail page showed the name as
  plain text. It is now a `ColorField` holding a 6-digit palette hex, picked
  with NetBox's core color widget and rendered as a swatch.
- Migration `0022` rewrites the existing values before narrowing the column.
  **A value it cannot resolve is cleared** -- six characters leaves no room
  for anything else -- so the migration prints every value it drops. Worth
  reading that output on a database with hand-written colors.
- CSV import still accepts a color name or a hex code, so existing import
  files keep working.

## Changes

- `models.py`: `color = ColorField(blank=True, ...)` in place of
  `CharField(max_length=50)`.
- `colors.py` (new): `color_to_hex()`. Resolves palette labels, the `COLOR_*`
  constant names (English even where the labels are translated), US "gray"
  spellings, and the names the palette lacks -- `slate` -> Dark Grey and
  `violet` -> Purple from the telecom 12-color code, plus `magenta`,
  `silver`, `natural`, `clear`. Returns `None` for anything unresolvable, so
  the migration can drop it while the import form rejects it.
- `migrations/0022_innerduct_color_hex.py`: data pass, then `AlterField`.
  Reversible -- palette hexes become names again.
- `forms.py`: bulk edit uses the core `ColorField`; import keeps a text field
  with `clean_color()`, which errors on an unknown color rather than silently
  blanking it.
- `filterforms.py`: the list filter gained the color picker, plus the `size`
  and `position` fields the filterset already accepted but the form never
  rendered.
- `tables.py`, `ui/panels.py`: `columns.ColorColumn` and `attrs.ColorAttr` --
  this covers the innerduct table on a conduit's detail page, the issue's
  second screenshot.
- `graphql/types.py`: `InnerductType.color: str`. Required, not cosmetic --
  strawberry has no mapping for `ColorField` and the schema raises
  `InnerductType fields cannot be resolved` without it. Core declares its
  color fields the same way.
- `search.py`: color dropped from the search index and `display_attrs`. It
  holds a hex code now; core indexes no color field either.
- `generate_sample_data.py`: seeds `ColorChoices` hex values.
- `tests/test_innerduct_color.py`: 26 tests -- the name-to-hex mappings, the
  four widget/column wiring points, import-form behavior, and the migration's
  data pass against real rows.
- `CHANGELOG.md`, `docs/user-guide/pathways.md`.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (584 passed)
- [x] New/changed behavior covered by tests
- [x] Migration applied cleanly, and verified against a real database rather
      than only in tests: seeded `orange`, `slate`, `unobtainium`, `#FF9800`
      and blank, then migrated. Result was `ff9800`, `607d8b`,
      cleared-with-warning, `ff9800`, blank, with the column narrowed to 6.
      Reversed it (values came back as names), re-applied, removed the seeded
      rows.
- [x] Docs updated (CHANGELOG + zensical user guide; no README change needed)

## Screenshots / output

All three forms render the palette -- 27 colors plus a blank option, with the
core `color-select` class:

```
InnerductForm         | options: 28 | class=color-select: True
InnerductBulkEditForm | options: 28 | class=color-select: True
InnerductFilterForm   | options: 28 | class=color-select: True
```

Migration output on an unresolvable value:

```
Applying netbox_pathways.0022_innerduct_color_hex...
  netbox_pathways: cleared 1 unrecognized innerduct color(s): unobtainium
```

## Related

Fixes: #79
