### PR TITLE
chore: drop stale issue references from source comments

### DIFF
--- a/netbox_pathways/checks.py
+++ b/netbox_pathways/checks.py
@@ -6,7 +6,7 @@ get_srid() is read from PLUGINS_CONFIG at form/serializer save time. If
 the two ever drift apart -- either because a migration shipped with a
 hardcoded SRID, or because an operator edited PLUGINS_CONFIG after
 applying migrations -- inserts fail with a SRID mismatch and crash the
-end user back to the home page (see issue #5).
+end user back to the home page.
 
 This module introspects geometry_columns and emits a checks.Error for
 every column whose stored SRID does not match get_srid(), with a hint

--- a/netbox_pathways/colors.py
+++ b/netbox_pathways/colors.py
@@ -1,6 +1,6 @@
 """Resolve color names to the hex codes NetBox's core color palette uses.
 
-Innerduct colors were free text until issue #79 and users typed names by
+Innerduct colors were free text originally, and users typed names by
 hand ("blue", "slate"). The field now stores a 6-digit hex code, so the
 0022 data migration and the CSV import form both need to translate those
 names -- and keep accepting them, since operators paste the same

--- a/netbox_pathways/coord_parser.py
+++ b/netbox_pathways/coord_parser.py
@@ -13,8 +13,6 @@ Supported input formats:
     - DMS with N/S/E/W hemispheres (point only)
     - DMS without hemispheres in lat-first order (point only)
     - Bare decimal "lat, lon" pairs in Google Maps order (point only)
-
-See issue #32.
 """
 
 from __future__ import annotations

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -148,7 +148,7 @@ class PathwaysMapWidget(BaseGeometryWidget):
         # Django 6.0 stopped exposing id/name/geom_type at the top level of the
         # widget context (they now live under ``widget``); our template reads
         # them at the top level, so re-expose them here. setdefault keeps this
-        # backwards compatible with Django <= 5.2, which still sets them. (#52)
+        # backwards compatible with Django <= 5.2, which still sets them.
         widget = context["widget"]
         context.setdefault("id", widget["attrs"].get("id", ""))
         context.setdefault("name", widget["name"])
@@ -1005,9 +1005,9 @@ class InnerductImportForm(PathwayPathFallbackMixin, NetBoxModelImportForm):
     )
 
     def clean_color(self):
-        # Colors were free text before issue #79, so imports that still name
-        # them keep working; anything unrecognized is an error rather than a
-        # silently blank field.
+        # Colors used to be free text, so imports that still name them keep
+        # working; anything unrecognized is an error rather than a silently
+        # blank field.
         color = self.cleaned_data.get("color")
         hex_code = color_to_hex(color)
         if hex_code is None:

--- a/netbox_pathways/migrations/0022_innerduct_color_hex.py
+++ b/netbox_pathways/migrations/0022_innerduct_color_hex.py
@@ -1,4 +1,4 @@
-"""Store Innerduct.color as a palette hex code instead of free text (issue #79).
+"""Store Innerduct.color as a palette hex code instead of free text.
 
 The old field accepted any 50-character string, so existing rows hold color
 names. They are translated to the matching hex code before the column is

--- a/netbox_pathways/search.py
+++ b/netbox_pathways/search.py
@@ -59,8 +59,7 @@ class InnerductIndex(SearchIndex):
         ("position", 300),
         ("comments", 5000),
     )
-    # Color is a hex code since issue #79 -- not worth indexing or displaying
-    # as text.
+    # Color is stored as a hex code -- not worth indexing or displaying as text.
     display_attrs = ("status", "parent_conduit", "size")
 
 

--- a/netbox_pathways/views.py
+++ b/netbox_pathways/views.py
@@ -1834,7 +1834,7 @@ class MapView(LoginRequiredMixin, View):
 
         ctx = {
             # Serialized with json_script in the template: locale-independent
-            # (see #93) and escaped against script-tag breakout.
+            # and escaped against script-tag breakout.
             "pathways_config": pathways_config,
             "map_init_config": {
                 "center": center,


### PR DESCRIPTION
## Summary

- Source comments and docstrings referenced specific GitHub issues in eight
  places. The issue number is the part that goes stale: it ages badly, means
  nothing to a reader without network access, and adds nothing the surrounding
  sentence does not already say. The explanations are kept; only the references
  are gone.
- Test docstrings are deliberately left alone. There, naming the issue is useful
  provenance for a regression test -- it says why the test exists.
- Comments only. No code, no behavior, no schema change.

## Changes

- `checks.py`: dropped "(see issue #5)" from the module docstring explaining the
  SRID-drift check.
- `colors.py`: "free text until issue #79" becomes "free text originally".
- `coord_parser.py`: dropped a trailing "See issue #32." paragraph that carried
  no information beyond the list of accepted formats above it.
- `forms.py`: dropped "(#52)" from the Django 6.0 widget-context note, and
  "before issue #79" from the color-import comment.
- `migrations/0022_innerduct_color_hex.py`: dropped "(issue #79)" from the
  docstring summary. Docstring only -- no migration operation is touched, and the
  migration's behavior and hash are unchanged.
- `search.py`: "a hex code since issue #79" becomes "stored as a hex code", and
  the comment now fits on one line.
- `views.py`: dropped "(see #93)" from the `json_script` serialization note.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes on `netbox_pathways/` (two
      `.devcontainer/configuration/*.py` files have pre-existing violations
      unrelated to this change)
- [x] `pytest` passes locally -- 548 passed, 0 failures
- [x] New/changed behavior covered by tests -- not applicable; every changed line
      is a comment or docstring, verified by reading the full diff line by line
- [ ] Migration applied cleanly -- not applicable, no schema change
- [ ] Docs updated -- not applicable, no user-visible change

## Related

Follow-up to the review of #110, which raised the same pattern in code that PR
introduced. Those four references were removed there; this sweeps the eight that
predate it.
