### PR TITLE
refactor: dedupe endpoint snap and bbox parsing helpers

### DIFF
--- a/netbox_pathways/api/external_geo.py
+++ b/netbox_pathways/api/external_geo.py
@@ -11,7 +11,6 @@ import logging
 
 from django.contrib.gis.db import models as gis_models
 from django.contrib.gis.db.models.functions import Transform
-from django.contrib.gis.geos import Polygon
 from django.db import models as db_models
 from django.db.models import F
 from django.db.models.functions import Coalesce
@@ -19,7 +18,7 @@ from django.http import Http404, JsonResponse
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 
-from netbox_pathways.api.geo import MAX_GEO_RESULTS
+from netbox_pathways.api.geo import MAX_GEO_RESULTS, _parse_bbox_wgs84
 from netbox_pathways.geo import LEAFLET_SRID, get_srid
 from netbox_pathways.registry import SUPPORTED_GEO_MODELS, registry
 
@@ -111,15 +110,9 @@ class ExternalLayerGeoView(APIView):
         ).exclude(_geo_4326__isnull=True)
 
         # Bbox filtering
-        bbox_str = request.query_params.get("bbox", "")
-        if bbox_str:
-            try:
-                w, s, e, n = (float(x) for x in bbox_str.split(","))
-                bbox_poly = Polygon.from_bbox((w, s, e, n))
-                bbox_poly.srid = LEAFLET_SRID
-                qs = qs.filter(_geo_4326__intersects=bbox_poly)
-            except (ValueError, TypeError):
-                pass  # ignore malformed bbox
+        bbox_poly, _ = _parse_bbox_wgs84(request.query_params.get("bbox"))
+        if bbox_poly is not None:
+            qs = qs.filter(_geo_4326__intersects=bbox_poly)
 
         qs = qs[:MAX_GEO_RESULTS]
 

--- a/netbox_pathways/api/geo.py
+++ b/netbox_pathways/api/geo.py
@@ -35,12 +35,10 @@ logger = logging.getLogger(__name__)
 MAX_GEO_RESULTS = 2000
 
 
-def _parse_bbox(value):
+def _parse_bbox_wgs84(value):
     """Parse a ``west,south,east,north`` string into a WGS84 Polygon.
 
     Returns ``(polygon, [w, s, e, n])`` or ``(None, None)`` on invalid input.
-    The polygon is already reprojected to the configured storage SRID, ready
-    to use in an ``__intersects`` lookup.
     """
     if not value:
         return None, None
@@ -50,9 +48,20 @@ def _parse_bbox(value):
         return None, None
     poly = Polygon.from_bbox((west, south, east, north))
     poly.srid = LEAFLET_SRID
-    if get_srid() != LEAFLET_SRID:
-        poly.transform(get_srid())
     return poly, [west, south, east, north]
+
+
+def _parse_bbox(value):
+    """Parse a ``west,south,east,north`` string into a WGS84 Polygon.
+
+    Returns ``(polygon, [w, s, e, n])`` or ``(None, None)`` on invalid input.
+    The polygon is already reprojected to the configured storage SRID, ready
+    to use in an ``__intersects`` lookup.
+    """
+    poly, bounds = _parse_bbox_wgs84(value)
+    if poly is not None and get_srid() != LEAFLET_SRID:
+        poly.transform(get_srid())
+    return poly, bounds
 
 
 def _etag_components(queryset):

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -379,8 +379,6 @@ class Pathway(NetBoxModel):
     def _validate_and_snap_endpoint(self, side):
         """Validate and snap one endpoint of self.path to the attached structure, or to the
         endpoint location's identity structure when no structure is set."""
-        from django.contrib.gis.geos import LineString, Point
-
         structure = getattr(self, f"{side}_structure", None)
         if not structure:
             location = getattr(self, f"{side}_location", None)
@@ -391,10 +389,20 @@ class Pathway(NetBoxModel):
         if not structure or not structure.geometry:
             return
 
+        self._snap_path_end(side, structure.geometry, "structure")
+
+    def _snap_path_end(self, side, geom, kind):
+        """Snap the path's <side> end to geom; raise if beyond tolerance.
+
+        geom may be a Point or an area geometry (snapped to its boundary).
+        kind names the endpoint type ("structure" or "junction") in the
+        validation message.
+        """
+        from django.contrib.gis.geos import LineString, Point
+
         coords = list(self.path.coords)
         idx = 0 if side == "start" else -1
         endpoint = Point(coords[idx][0], coords[idx][1], srid=self.path.srid)
-        geom = structure.geometry
 
         if geom.geom_type == "Point":
             if endpoint.distance(geom) <= ENDPOINT_TOLERANCE:
@@ -402,7 +410,7 @@ class Pathway(NetBoxModel):
             else:
                 raise ValidationError(
                     {
-                        "path": f"Path {side} point is too far from the {side} structure "
+                        "path": f"Path {side} point is too far from the {side} {kind} "
                         f"(must be within {ENDPOINT_TOLERANCE}m)."
                     }
                 )
@@ -415,7 +423,7 @@ class Pathway(NetBoxModel):
             else:
                 raise ValidationError(
                     {
-                        "path": f"Path {side} point is too far from the {side} structure "
+                        "path": f"Path {side} point is too far from the {side} {kind} "
                         f"(must be within {ENDPOINT_TOLERANCE}m of the boundary)."
                     }
                 )
@@ -615,8 +623,6 @@ class Conduit(Pathway):
 
     def _validate_and_snap_junction(self, side):
         """Validate and snap one endpoint to the attached junction's location."""
-        from django.contrib.gis.geos import LineString, Point
-
         junction = getattr(self, f"{side}_junction", None)
         if not junction:
             return
@@ -624,20 +630,7 @@ class Conduit(Pathway):
         if junc_loc is None:
             return
 
-        coords = list(self.path.coords)
-        idx = 0 if side == "start" else -1
-        endpoint = Point(coords[idx][0], coords[idx][1], srid=self.path.srid)
-
-        if endpoint.distance(junc_loc) <= ENDPOINT_TOLERANCE:
-            coords[idx] = (junc_loc.x, junc_loc.y)
-            self.path = LineString(coords, srid=self.path.srid)
-        else:
-            raise ValidationError(
-                {
-                    "path": f"Path {side} point is too far from the {side} junction "
-                    f"(must be within {ENDPOINT_TOLERANCE}m)."
-                }
-            )
+        self._snap_path_end(side, junc_loc, "junction")
 
     def save(self, *args, **kwargs):
         self.pathway_type = "conduit"

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -622,15 +622,15 @@ class Conduit(Pathway):
             self._validate_and_snap_junction("end")
 
     def _validate_and_snap_junction(self, side):
-        """Validate and snap one endpoint to the attached junction's location."""
+        """Validate and snap one endpoint to the attached junction's derived point."""
         junction = getattr(self, f"{side}_junction", None)
         if not junction:
             return
-        junc_loc = junction.location
-        if junc_loc is None:
+        junc_geom = junction.derived_geometry
+        if junc_geom is None:
             return
 
-        self._snap_path_end(side, junc_loc, "junction")
+        self._snap_path_end(side, junc_geom, "junction")
 
     def save(self, *args, **kwargs):
         self.pathway_type = "conduit"
@@ -811,7 +811,12 @@ class ConduitJunction(NetBoxModel):
                 )
 
     @property
-    def location(self):
+    def derived_geometry(self):
+        """Point on the trunk conduit's path at position_on_trunk.
+
+        Derived, not stored: a junction carries no geometry column and no
+        dcim.Location relation.
+        """
         if self.trunk_conduit and self.trunk_conduit.path:
             return self.trunk_conduit.path.interpolate_normalized(self.position_on_trunk)
         return None

--- a/netbox_pathways/template_content.py
+++ b/netbox_pathways/template_content.py
@@ -207,12 +207,12 @@ class PluginModelMapExtension(PluginTemplateExtension):
                 if line:
                     data["lines"].append(line)
             # Show the computed junction point
-            loc = obj.location
-            if loc:
+            point = obj.derived_geometry
+            if point:
                 data["points"].append(
                     {
-                        "lat": loc.y,
-                        "lon": loc.x,
+                        "lat": point.y,
+                        "lon": point.x,
                         "name": str(obj),
                         "color": "red",
                     }


### PR DESCRIPTION
## Summary
- Housekeeping follow-up from the DRY review of #113: removes two pieces of pre-existing knowledge duplication. No behavior change.
- `Pathway._snap_path_end(side, geom, kind)` now owns the snap-and-validate logic; `_validate_and_snap_endpoint` (structures, incl. the identity fallback) and `Conduit._validate_and_snap_junction` only resolve their endpoint and delegate.
- `_parse_bbox_wgs84()` in `api/geo.py` owns bbox-string parsing; `_parse_bbox` layers the storage-SRID transform on it, and `external_geo.py` reuses the primitive instead of its inline parse.
- `ConduitJunction.location` (a computed property, not a field) is renamed to `derived_geometry`: it returns a point interpolated along the trunk conduit's path, while `location` everywhere else in the plugin now means an FK to `dcim.Location`.

## Changes
- `netbox_pathways/models.py`: shared `_snap_path_end` helper; error messages unchanged per test regexes. `ConduitJunction.derived_geometry` rename (property only, no migration).
- `netbox_pathways/template_content.py`: junction detail map reads `derived_geometry`.
- `netbox_pathways/api/geo.py`: `_parse_bbox` split into WGS84 primitive + storage transform; public contract unchanged.
- `netbox_pathways/api/external_geo.py`: inline bbox parse replaced by the shared primitive; unused `Polygon` import dropped.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (567 passed, coverage 79.40%)
- [x] New/changed behavior covered by tests (behavior-preserving; existing endpoint-validation, geo API, and map view tests are the net)
- [ ] Migration applied cleanly (n/a -- no schema change)
- [ ] Docs updated (n/a -- internal refactor, not user-visible)

## Screenshots / output
n/a

## Related
Refs #113

~~Stacked on #113~~ #113 merged; retargeted to `main` and rebased (2026-08-05).
