### PR TITLE
feat(views): show bank position in conduit bank conduits table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Conduits table on a conduit bank's detail page now shows the Bank
+  Position column instead of the redundant Conduit Bank column, which only
+  linked back to the page being viewed. The standalone Conduits list view
+  is unchanged. Requested by @marcusyuri. Refs #76.
+
 - **Innerduct color is now picked from NetBox's color palette** instead of
   typed as free text. The edit, bulk-edit and list-filter forms use the core
   color widget, and innerduct tables -- including the one on a conduit's

--- a/netbox_pathways/tables.py
+++ b/netbox_pathways/tables.py
@@ -169,6 +169,22 @@ class ConduitTable(NetBoxTable):
             "cables_routed",
         )
 
+    def configure(self, request):
+        super().configure(request)
+        # NetBox 4.5 ignores the include_columns/exclude_columns URL params
+        # that 4.6's NetBoxTable.configure() applies natively; backport that
+        # handling so the conduit bank detail page can swap the redundant
+        # conduit_bank column for bank_position. Idempotent on 4.6 -- remove
+        # once the minimum supported NetBox is 4.6.
+        if include_columns := request.GET.get("include_columns"):
+            for column_name in include_columns.split(","):
+                if column_name in self.columns.names():
+                    self.columns.show(column_name)
+        if exclude_columns := request.GET.get("exclude_columns"):
+            for column_name in exclude_columns.split(","):
+                if column_name in self.columns.names() and column_name not in self.exempt_columns:
+                    self.columns.hide(column_name)
+
 
 class AerialSpanTable(NetBoxTable):
     aerial_span = tables.TemplateColumn(

--- a/netbox_pathways/views.py
+++ b/netbox_pathways/views.py
@@ -602,6 +602,8 @@ class ConduitBankView(generic.ObjectView):
                 model="netbox_pathways.Conduit",
                 title="Conduits",
                 filters={"conduit_bank_id": lambda ctx: ctx["object"].pk},
+                include_columns=["bank_position"],
+                exclude_columns=["conduit_bank"],
             ),
         ],
     )

--- a/netbox_pathways/views.py
+++ b/netbox_pathways/views.py
@@ -598,12 +598,18 @@ class ConduitBankView(generic.ObjectView):
             CommentsPanel(),
         ],
         bottom_panels=[
+            # The column overrides ride along as URL params instead of the
+            # panel's include_columns/exclude_columns kwargs, which NetBox
+            # 4.5 does not accept; ConduitTable.configure() applies them on
+            # NetBox versions whose core does not.
             ObjectsTablePanel(
                 model="netbox_pathways.Conduit",
                 title="Conduits",
-                filters={"conduit_bank_id": lambda ctx: ctx["object"].pk},
-                include_columns=["bank_position"],
-                exclude_columns=["conduit_bank"],
+                filters={
+                    "conduit_bank_id": lambda ctx: ctx["object"].pk,
+                    "include_columns": "bank_position",
+                    "exclude_columns": "conduit_bank",
+                },
             ),
         ],
     )

--- a/tests/test_view_layouts.py
+++ b/tests/test_view_layouts.py
@@ -1,8 +1,13 @@
 """Tests for detail-view layout panel configuration."""
 
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
 from netbox.ui.panels import ObjectsTablePanel
 
 from netbox_pathways import views
+from netbox_pathways.models import Conduit
+from netbox_pathways.tables import ConduitTable
 
 
 def _iter_panels(layout):
@@ -11,14 +16,40 @@ def _iter_panels(layout):
             yield from column
 
 
-def test_conduit_bank_conduits_panel_swaps_bank_column_for_position():
-    """The Conduits table embedded in a conduit bank's detail page hides
-    the redundant conduit_bank column (it links back to the page being
-    viewed) and shows bank_position instead. Regression test for #76."""
-    panel = next(
+def _conduits_panel():
+    return next(
         p
         for p in _iter_panels(views.ConduitBankView.layout)
         if isinstance(p, ObjectsTablePanel) and p.model_label == "netbox_pathways.Conduit"
     )
-    assert "conduit_bank" in panel.exclude_columns
-    assert "bank_position" in panel.include_columns
+
+
+def test_conduit_bank_conduits_panel_swaps_bank_column_for_position():
+    """The Conduits table embedded in a conduit bank's detail page hides
+    the redundant conduit_bank column (it links back to the page being
+    viewed) and shows bank_position instead. The overrides travel as URL
+    params via `filters` rather than the panel's include_columns /
+    exclude_columns kwargs, which NetBox 4.5 does not accept. Regression
+    test for #76."""
+    panel = _conduits_panel()
+    assert panel.filters.get("include_columns") == "bank_position"
+    assert panel.filters.get("exclude_columns") == "conduit_bank"
+
+
+@pytest.mark.django_db
+def test_conduit_table_configure_applies_column_override_params():
+    """NetBox 4.5 ignores the include_columns/exclude_columns URL params
+    that 4.6 applies in NetBoxTable.configure(), so ConduitTable backports
+    the handling. On 4.6 this exercises the idempotent overlap of the
+    backport and core. Regression test for the #76 CI failure on the
+    4.5.x matrix."""
+    request = RequestFactory().get(
+        "/",
+        {"include_columns": "bank_position", "exclude_columns": "conduit_bank"},
+    )
+    request.user = AnonymousUser()
+    table = ConduitTable(Conduit.objects.none())
+    table.configure(request)
+    visible = [column.name for column in table.columns if column.visible]
+    assert "bank_position" in visible
+    assert "conduit_bank" not in visible

--- a/tests/test_view_layouts.py
+++ b/tests/test_view_layouts.py
@@ -1,0 +1,24 @@
+"""Tests for detail-view layout panel configuration."""
+
+from netbox.ui.panels import ObjectsTablePanel
+
+from netbox_pathways import views
+
+
+def _iter_panels(layout):
+    for row in layout:
+        for column in row:
+            yield from column
+
+
+def test_conduit_bank_conduits_panel_swaps_bank_column_for_position():
+    """The Conduits table embedded in a conduit bank's detail page hides
+    the redundant conduit_bank column (it links back to the page being
+    viewed) and shows bank_position instead. Regression test for #76."""
+    panel = next(
+        p
+        for p in _iter_panels(views.ConduitBankView.layout)
+        if isinstance(p, ObjectsTablePanel) and p.model_label == "netbox_pathways.Conduit"
+    )
+    assert "conduit_bank" in panel.exclude_columns
+    assert "bank_position" in panel.include_columns

--- a/tests/test_view_layouts.py
+++ b/tests/test_view_layouts.py
@@ -11,16 +11,18 @@ from netbox_pathways.tables import ConduitTable
 
 
 def _iter_panels(layout):
-    for row in layout:
-        for column in row:
-            yield from column
+    # Walk the plain attributes rather than iterating the objects: the
+    # Layout/Row/Column __iter__ methods and the panel's model_label
+    # attribute only exist on NetBox 4.6, while `model` resolves to the
+    # model class on both 4.5 and 4.6.
+    for row in layout.rows:
+        for column in row.columns:
+            yield from column.panels
 
 
 def _conduits_panel():
     return next(
-        p
-        for p in _iter_panels(views.ConduitBankView.layout)
-        if isinstance(p, ObjectsTablePanel) and p.model_label == "netbox_pathways.Conduit"
+        p for p in _iter_panels(views.ConduitBankView.layout) if isinstance(p, ObjectsTablePanel) and p.model is Conduit
     )
 
 


### PR DESCRIPTION
## Summary
- The Conduits table embedded in a conduit bank's detail page listed a Conduit Bank column that only linked back to the page being viewed.
- Hide it there and surface the Bank Position column instead, so the per-conduit position is visible without opening each conduit.
- The overrides travel as URL params via ObjectsTablePanel's `filters` argument (valid on NetBox 4.5 and 4.6); the panel-level `include_columns`/`exclude_columns` kwargs and their URL-param handling are 4.6-only, so ConduitTable.configure() backports the param handling for 4.5 (idempotent on 4.6, removable once the minimum supported NetBox is 4.6).
- The standalone Conduits list view and user column preferences elsewhere are unchanged.

## Changes
- netbox_pathways/views.py: pass include_columns/exclude_columns as URL params in the Conduits ObjectsTablePanel filters on ConduitBankView.
- netbox_pathways/tables.py: ConduitTable.configure() override backporting NetBox 4.6's include_columns/exclude_columns URL-param handling.
- tests/test_view_layouts.py: regression tests for the panel filters and the configure() backport.
- CHANGELOG.md: entry under [Unreleased] / Changed.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] New tests fail before the change and pass after (`tests/test_view_layouts.py`)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (n/a -- no schema change)
- [x] Docs updated (CHANGELOG; no README/zensical page documents detail-page columns)

## Related
Fixes: #76