### PR TITLE
feat: add-child buttons that inherit parent attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Add-child buttons that inherit the parent's attributes.** The Conduits
+  panel on a conduit bank and the Innerducts panel on a conduit now carry
+  an "Add" button that opens the create form pre-filled from the parent:
+  endpoints and faces for bank conduits (plus installed-by and dates),
+  endpoints for innerducts. Blank endpoints on a bank conduit now inherit
+  from the bank at save time, matching the existing innerduct behavior,
+  and contained pathways (bank conduits, innerducts) no longer require or
+  synthesize their own path geometry -- the parent owns the route. Tenant
+  columns on the conduit and innerduct tables fall back to the parent
+  chain's tenant, marked with `*` in the NetBox style.
+  Requested by @marcusyuri. Refs #77.
+
 - **Hide unoccupied toggle on the interactive map.** A new sidebar button
   under Hide inactive filters every layer down to plant that carries cable:
   pathways with at least one routed segment and the structures terminating

--- a/docs/user-guide/conduit-banks.md
+++ b/docs/user-guide/conduit-banks.md
@@ -90,6 +90,23 @@ GeoJSON endpoints).
 To inspect the conduits inside a bank, open the bank detail page in NetBox
 and use the conduits panel.
 
+## Adding conduits to a bank
+
+The Conduits panel on a conduit bank's detail page has an Add button that
+opens the conduit create form pre-filled from the bank: start/end
+structures or locations, faces, installer, and dates. Adjust anything
+before saving; every value is a plain form field.
+
+Endpoints may also be left blank: a conduit that belongs to a bank
+inherits the bank's endpoints when it is saved, the same way an innerduct
+inherits from its parent conduit. Conduits inside a bank never need their
+own path geometry -- the bank owns the route -- and the bank is the
+feature drawn on the map.
+
+If a conduit has no tenant of its own, tables show the bank's tenant
+marked with `*`, following the NetBox convention for inherited tenancy.
+Assign a tenant on the conduit itself to override it.
+
 ## Validation
 
 Bank endpoints follow the same rules as any pathway:

--- a/docs/user-guide/pathways.md
+++ b/docs/user-guide/pathways.md
@@ -63,6 +63,14 @@ map onto the nearest palette entries.
 
 Innerducts inherit start and end endpoints (structures or locations) from their parent conduit if not explicitly set.
 
+The Innerducts panel on a conduit's detail page has an Add button that
+opens the innerduct create form with the parent conduit and its endpoints
+pre-filled. Innerducts never need their own path geometry -- the parent
+conduit owns the route. Lifecycle fields (installer, dates) are not
+inherited: innerducts are usually installed separately. An innerduct
+without a tenant shows the parent chain's tenant marked with `*` in
+tables.
+
 ## Endpoints
 
 Every pathway has a start endpoint and an end endpoint. These can be:

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -165,7 +165,8 @@ class PathwayPathFallbackMixin:
     Shared by the interactive pathway forms and the CSV import forms so both
     have the same semantics: structure-to-structure entries get a straight
     LineString between the structures, location-to-location (indoor) entries
-    need no geographic path at all.
+    need no geographic path at all. Contained pathways (conduits in banks,
+    innerducts) follow the parent's route and need no path.
     """
 
     def clean(self):
@@ -175,20 +176,15 @@ class PathwayPathFallbackMixin:
         if path:
             return cleaned
 
+        # Contained pathways (a conduit in a bank, an innerduct) follow the
+        # parent's route; never synthesize a standalone path for them.
+        if cleaned.get("conduit_bank") or cleaned.get("parent_conduit"):
+            return cleaned
+
         start_struct = cleaned.get("start_structure")
         end_struct = cleaned.get("end_structure")
         start_loc = cleaned.get("start_location")
         end_loc = cleaned.get("end_location")
-
-        # Innerduct fallback: use parent conduit's endpoints, per side
-        parent = cleaned.get("parent_conduit")
-        if parent:
-            if not start_struct and not start_loc:
-                start_struct = parent.start_structure
-                start_loc = parent.start_location
-            if not end_struct and not end_loc:
-                end_struct = parent.end_structure
-                end_loc = parent.end_location
 
         # Indoor pathway (both endpoints are locations): no geographic path exists
         if start_loc and end_loc and not start_struct and not end_struct:

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -238,6 +238,38 @@ class PathwayEndpointFormMixin(PathwayPathFallbackMixin):
         widget.endpoint_geojson = endpoint_data if endpoint_data else None
 
 
+def _resolve_initial_parent(form, field_name, queryset):
+    """Resolve a parent object from a pk passed in form initial data.
+
+    Returns None when editing an existing object, when the initial is
+    absent, or when the pk does not resolve to a row.
+    """
+    if form.instance.pk:
+        return None
+    raw = form.initial.get(field_name)
+    if not raw:
+        return None
+    try:
+        return queryset.get(pk=raw)
+    except (queryset.model.DoesNotExist, ValueError, TypeError):
+        return None
+
+
+def _prefill_initial_from_parent(form, parent, field_names):
+    """Copy parent attribute values into form initial for absent keys.
+
+    Values already present in initial (explicit GET params) always win.
+    FK values are stored as pks so dynamic choice fields render them.
+    """
+    for name in field_names:
+        if form.initial.get(name) not in (None, ""):
+            continue
+        value = getattr(parent, name, None)
+        if value in (None, ""):
+            continue
+        form.initial[name] = value.pk if hasattr(value, "pk") else value
+
+
 # --- Structure ---
 
 
@@ -452,24 +484,28 @@ class ConduitForm(PathwayEndpointFormMixin, NetBoxModelForm):
         required=False,
         selector=True,
         quick_add=True,
+        help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
     end_structure = DynamicModelChoiceField(
         queryset=Structure.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
+        help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
     start_location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
+        help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
     end_location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
+        help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
     conduit_bank = DynamicModelChoiceField(
         queryset=ConduitBank.objects.all(),
@@ -497,6 +533,26 @@ class ConduitForm(PathwayEndpointFormMixin, NetBoxModelForm):
         quick_add=True,
         label="Installed by",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        bank = _resolve_initial_parent(self, "conduit_bank", ConduitBank.objects.all())
+        if bank:
+            _prefill_initial_from_parent(
+                self,
+                bank,
+                [
+                    "start_structure",
+                    "end_structure",
+                    "start_location",
+                    "end_location",
+                    "start_face",
+                    "end_face",
+                    "installed_by",
+                    "installation_date",
+                    "commissioned_date",
+                ],
+            )
 
     fieldsets = (
         FieldSet("label", "status", "material", "length", name="Conduit"),
@@ -940,6 +996,16 @@ class InnerductForm(PathwayEndpointFormMixin, NetBoxModelForm):
         quick_add=True,
         label="Installed by",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        parent = _resolve_initial_parent(self, "parent_conduit", Conduit.objects.all())
+        if parent:
+            _prefill_initial_from_parent(
+                self,
+                parent,
+                ["start_structure", "end_structure", "start_location", "end_location"],
+            )
 
     fieldsets = (
         FieldSet("label", "status", "parent_conduit", "size", "color", "position", name="Innerduct"),

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -487,28 +487,24 @@ class ConduitForm(PathwayEndpointFormMixin, NetBoxModelForm):
         required=False,
         selector=True,
         quick_add=True,
-        help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
     end_structure = DynamicModelChoiceField(
         queryset=Structure.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
-        help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
     start_location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
-        help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
     end_location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
-        help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
     start_face = forms.ChoiceField(choices=BankFaceChoices, required=False)
     end_face = forms.ChoiceField(choices=BankFaceChoices, required=False)
@@ -980,28 +976,24 @@ class InnerductForm(PathwayEndpointFormMixin, NetBoxModelForm):
         required=False,
         selector=True,
         quick_add=True,
-        help_text="Leave blank to inherit from parent conduit",
     )
     end_structure = DynamicModelChoiceField(
         queryset=Structure.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
-        help_text="Leave blank to inherit from parent conduit",
     )
     start_location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
-        help_text="Leave blank to inherit from parent conduit",
     )
     end_location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
         selector=True,
         quick_add=True,
-        help_text="Leave blank to inherit from parent conduit",
     )
 
     installed_by = DynamicModelChoiceField(

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -507,6 +507,8 @@ class ConduitForm(PathwayEndpointFormMixin, NetBoxModelForm):
         quick_add=True,
         help_text="Leave blank to inherit from the conduit bank, if one is set",
     )
+    start_face = forms.ChoiceField(choices=BankFaceChoices, required=False)
+    end_face = forms.ChoiceField(choices=BankFaceChoices, required=False)
     conduit_bank = DynamicModelChoiceField(
         queryset=ConduitBank.objects.all(),
         required=False,
@@ -557,7 +559,15 @@ class ConduitForm(PathwayEndpointFormMixin, NetBoxModelForm):
     fieldsets = (
         FieldSet("label", "status", "material", "length", name="Conduit"),
         FieldSet("installed_by", "installation_date", "commissioned_date", name="Lifecycle"),
-        FieldSet("start_structure", "end_structure", "start_location", "end_location", name="Endpoints"),
+        FieldSet(
+            "start_structure",
+            "end_structure",
+            "start_location",
+            "end_location",
+            "start_face",
+            "end_face",
+            name="Endpoints",
+        ),
         FieldSet("start_junction", "end_junction", name="Junctions"),
         FieldSet("inner_diameter", "outer_diameter", "depth", name="Dimensions"),
         FieldSet("conduit_bank", "bank_position", name="Conduit Bank"),
@@ -576,6 +586,8 @@ class ConduitForm(PathwayEndpointFormMixin, NetBoxModelForm):
             "end_structure",
             "start_location",
             "end_location",
+            "start_face",
+            "end_face",
             "start_junction",
             "end_junction",
             "inner_diameter",

--- a/netbox_pathways/forms.py
+++ b/netbox_pathways/forms.py
@@ -238,9 +238,11 @@ class PathwayEndpointFormMixin(PathwayPathFallbackMixin):
         widget.endpoint_geojson = endpoint_data if endpoint_data else None
 
 
-def _resolve_initial_parent(form, field_name, queryset):
+def _resolve_initial_parent(form, field_name):
     """Resolve a parent object from a pk passed in form initial data.
 
+    Reads the queryset from the form field itself (`form.fields[field_name].queryset`)
+    rather than taking one as an argument, since the field already declares it.
     Returns None when editing an existing object, when the initial is
     absent, or when the pk does not resolve to a row.
     """
@@ -249,6 +251,7 @@ def _resolve_initial_parent(form, field_name, queryset):
     raw = form.initial.get(field_name)
     if not raw:
         return None
+    queryset = form.fields[field_name].queryset
     try:
         return queryset.get(pk=raw)
     except (queryset.model.DoesNotExist, ValueError, TypeError):
@@ -538,7 +541,7 @@ class ConduitForm(PathwayEndpointFormMixin, NetBoxModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        bank = _resolve_initial_parent(self, "conduit_bank", ConduitBank.objects.all())
+        bank = _resolve_initial_parent(self, "conduit_bank")
         if bank:
             _prefill_initial_from_parent(
                 self,
@@ -1011,7 +1014,7 @@ class InnerductForm(PathwayEndpointFormMixin, NetBoxModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        parent = _resolve_initial_parent(self, "parent_conduit", Conduit.objects.all())
+        parent = _resolve_initial_parent(self, "parent_conduit")
         if parent:
             _prefill_initial_from_parent(
                 self,

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -457,6 +457,19 @@ class Pathway(NetBoxModel):
         """
         return True
 
+    def _inherit_endpoints_from(self, parent, occupied_suffixes=("structure_id", "location_id")):
+        """Inherit endpoints from a parent pathway, per side, if not explicitly set.
+
+        A side counts as occupied when any of the given FK suffixes is set on it.
+        """
+        if parent is None:
+            return
+        for side in ("start", "end"):
+            if any(getattr(self, f"{side}_{sfx}") for sfx in occupied_suffixes):
+                continue
+            setattr(self, f"{side}_structure", getattr(parent, f"{side}_structure"))
+            setattr(self, f"{side}_location", getattr(parent, f"{side}_location"))
+
     @classmethod
     def map_queryset(cls, queryset=None):
         """Return a queryset filtered to only map-visible pathways.
@@ -634,14 +647,10 @@ class Conduit(Pathway):
 
     def _inherit_bank_endpoints(self):
         """Inherit endpoints from the conduit bank, per side, if not explicitly set."""
-        if not self.conduit_bank_id:
-            return
-        if not any([self.start_structure_id, self.start_location_id, self.start_junction_id]):
-            self.start_structure = self.conduit_bank.start_structure
-            self.start_location = self.conduit_bank.start_location
-        if not any([self.end_structure_id, self.end_location_id, self.end_junction_id]):
-            self.end_structure = self.conduit_bank.end_structure
-            self.end_location = self.conduit_bank.end_location
+        self._inherit_endpoints_from(
+            self.conduit_bank if self.conduit_bank_id else None,
+            ("structure_id", "location_id", "junction_id"),
+        )
 
     def clean(self):
         # Inherit before validation so the exactly-one-endpoint-per-side
@@ -781,14 +790,7 @@ class Innerduct(Pathway):
 
     def _inherit_parent_endpoints(self):
         """Inherit endpoints from the parent conduit, per side, if not explicitly set."""
-        if not self.parent_conduit_id:
-            return
-        if not any([self.start_structure_id, self.start_location_id]):
-            self.start_structure = self.parent_conduit.start_structure
-            self.start_location = self.parent_conduit.start_location
-        if not any([self.end_structure_id, self.end_location_id]):
-            self.end_structure = self.parent_conduit.end_structure
-            self.end_location = self.parent_conduit.end_location
+        self._inherit_endpoints_from(self.parent_conduit if self.parent_conduit_id else None)
 
     def clean(self):
         # Inherit before validation so the path-required check sees the

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -619,7 +619,21 @@ class Conduit(Pathway):
             ),
         ]
 
+    def _inherit_bank_endpoints(self):
+        """Inherit endpoints from the conduit bank, per side, if not explicitly set."""
+        if not self.conduit_bank_id:
+            return
+        if not any([self.start_structure_id, self.start_location_id, self.start_junction_id]):
+            self.start_structure = self.conduit_bank.start_structure
+            self.start_location = self.conduit_bank.start_location
+        if not any([self.end_structure_id, self.end_location_id, self.end_junction_id]):
+            self.end_structure = self.conduit_bank.end_structure
+            self.end_location = self.conduit_bank.end_location
+
     def clean(self):
+        # Inherit before validation so the exactly-one-endpoint-per-side
+        # check and path snapping see the effective endpoints.
+        self._inherit_bank_endpoints()
         super().clean()  # Pathway.clean() handles structure endpoints
         start_options = sum(bool(x) for x in [self.start_structure, self.start_location, self.start_junction])
         end_options = sum(bool(x) for x in [self.end_structure, self.end_location, self.end_junction])
@@ -651,6 +665,7 @@ class Conduit(Pathway):
 
     def save(self, *args, **kwargs):
         self.pathway_type = "conduit"
+        self._inherit_bank_endpoints()
         super().save(*args, **kwargs)
 
 

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -365,10 +365,20 @@ class Pathway(NetBoxModel):
         value = Pathway.objects.with_geo_length().values_list("_geo_length", flat=True).get(pk=self.pk)
         return _distance_to_m(value)
 
+    @property
+    def requires_path(self):
+        """Whether clean() demands a geometry path.
+
+        Indoor pathways (both endpoints are locations) carry no geographic
+        path. Subclasses contained in a parent pathway override this: the
+        parent owns the route geometry.
+        """
+        return not self.is_indoor
+
     def clean(self):
         super().clean()
         if not self.path:
-            if not self.is_indoor:
+            if self.requires_path:
                 raise ValidationError(
                     {"path": "Path is required unless both endpoints are locations (indoor pathway)."}
                 )
@@ -584,6 +594,13 @@ class Conduit(Pathway):
         return self.conduit_bank_id is None
 
     @property
+    def requires_path(self):
+        """A conduit inside a bank follows the bank's route; no own path needed."""
+        if self.conduit_bank_id:
+            return False
+        return super().requires_path
+
+    @property
     def is_indoor(self):
         """Junction endpoints are geographic, so they also preclude indoor status."""
         return super().is_indoor and not self.start_junction_id and not self.end_junction_id
@@ -710,6 +727,11 @@ class Innerduct(Pathway):
 
     @property
     def map_visible(self):
+        return False
+
+    @property
+    def requires_path(self):
+        """An innerduct follows its parent conduit's geometry."""
         return False
 
     size = models.CharField(max_length=50, help_text='Innerduct size (e.g., 1.25", 32mm)')

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -594,6 +594,19 @@ class Conduit(Pathway):
         return self.conduit_bank_id is None
 
     @property
+    def effective_tenant(self):
+        """Own tenant, or the conduit bank's when not set.
+
+        Display-layer fallback in the NetBox VRF/prefix style: the stored
+        field stays authoritative for filtering and the API.
+        """
+        if self.tenant_id:
+            return self.tenant
+        if self.conduit_bank_id:
+            return self.conduit_bank.tenant
+        return None
+
+    @property
     def requires_path(self):
         """A conduit inside a bank follows the bank's route; no own path needed."""
         if self.conduit_bank_id:
@@ -743,6 +756,15 @@ class Innerduct(Pathway):
     @property
     def map_visible(self):
         return False
+
+    @property
+    def effective_tenant(self):
+        """Own tenant, or the parent chain's (conduit, then bank) when not set."""
+        if self.tenant_id:
+            return self.tenant
+        if self.parent_conduit_id:
+            return self.parent_conduit.effective_tenant
+        return None
 
     @property
     def requires_path(self):

--- a/netbox_pathways/tables.py
+++ b/netbox_pathways/tables.py
@@ -27,6 +27,16 @@ _MAP_BUTTON = (
     '<i class="mdi mdi-map-marker-radius"></i></a>'
 )
 
+_TENANT_COLUMN = """
+{% if record.tenant %}
+    <a href="{{ record.tenant.get_absolute_url }}" title="{{ record.tenant.description }}">{{ record.tenant }}</a>
+{% elif record.effective_tenant %}
+    <a href="{{ record.effective_tenant.get_absolute_url }}" title="Inherited from the parent pathway">{{ record.effective_tenant }}</a>*
+{% else %}
+    &mdash;
+{% endif %}
+"""
+
 
 class StructureTable(NetBoxTable):
     name = tables.Column(linkify=True)
@@ -128,6 +138,11 @@ class ConduitTable(NetBoxTable):
     start_location = tables.Column(linkify=True)
     end_location = tables.Column(linkify=True)
     conduit_bank = tables.Column(linkify=True)
+    tenant = tables.TemplateColumn(
+        template_code=_TENANT_COLUMN,
+        verbose_name="Tenant",
+        order_by="tenant",
+    )
     installed_by = tables.Column(linkify=True, verbose_name="Installed by")
     geo_length = tables.Column(verbose_name="Geo length (m)", order_by="_geo_length")
     cables_routed = tables.Column(verbose_name="Cables", orderable=True)
@@ -148,6 +163,7 @@ class ConduitTable(NetBoxTable):
             "start_location",
             "end_location",
             "conduit_bank",
+            "tenant",
             "bank_position",
             "length",
             "geo_length",
@@ -283,6 +299,11 @@ class InnerductTable(NetBoxTable):
     )
     status = columns.ChoiceFieldColumn()
     parent_conduit = tables.Column(linkify=True)
+    tenant = tables.TemplateColumn(
+        template_code=_TENANT_COLUMN,
+        verbose_name="Tenant",
+        order_by="tenant",
+    )
     color = columns.ColorColumn()
     installed_by = tables.Column(linkify=True, verbose_name="Installed by")
     cables_routed = tables.Column(verbose_name="Cables", orderable=True)
@@ -298,6 +319,7 @@ class InnerductTable(NetBoxTable):
             "label",
             "status",
             "parent_conduit",
+            "tenant",
             "size",
             "color",
             "position",

--- a/netbox_pathways/views.py
+++ b/netbox_pathways/views.py
@@ -301,6 +301,7 @@ class ConduitListView(generic.ObjectListView):
         "start_location",
         "end_location",
         "conduit_bank",
+        "conduit_bank__tenant",
         "tenant",
     ).annotate(
         cables_routed=Count("cable_segments"),
@@ -524,7 +525,12 @@ class DirectBuriedBulkDeleteView(generic.BulkDeleteView):
 
 
 class InnerductListView(generic.ObjectListView):
-    queryset = models.Innerduct.objects.select_related("parent_conduit").annotate(
+    queryset = models.Innerduct.objects.select_related(
+        "parent_conduit",
+        "tenant",
+        "parent_conduit__tenant",
+        "parent_conduit__conduit_bank__tenant",
+    ).annotate(
         cables_routed=Count("cable_segments"),
         in_use=Exists(models.CableSegment.objects.filter(pathway=OuterRef("pk"))),
         _geo_length=Length("path"),

--- a/netbox_pathways/views.py
+++ b/netbox_pathways/views.py
@@ -22,6 +22,7 @@ from netbox.object_actions import (
     EditObject,
     ObjectAction,
 )
+from netbox.ui import actions as ui_actions
 from netbox.ui import layout
 from netbox.ui.panels import CommentsPanel, ObjectsTablePanel, TemplatePanel
 from netbox.views import generic
@@ -326,6 +327,12 @@ class ConduitView(generic.ObjectView):
                 model="netbox_pathways.Innerduct",
                 title="Innerducts",
                 filters={"parent_conduit_id": lambda ctx: ctx["object"].pk},
+                actions=[
+                    ui_actions.AddObject(
+                        "netbox_pathways.Innerduct",
+                        url_params={"parent_conduit": lambda ctx: ctx["object"].pk},
+                    ),
+                ],
             ),
             ObjectsTablePanel(
                 model="netbox_pathways.CableSegment",
@@ -602,6 +609,12 @@ class ConduitBankView(generic.ObjectView):
                 model="netbox_pathways.Conduit",
                 title="Conduits",
                 filters={"conduit_bank_id": lambda ctx: ctx["object"].pk},
+                actions=[
+                    ui_actions.AddObject(
+                        "netbox_pathways.Conduit",
+                        url_params={"conduit_bank": lambda ctx: ctx["object"].pk},
+                    ),
+                ],
             ),
         ],
     )

--- a/tests/test_effective_tenant.py
+++ b/tests/test_effective_tenant.py
@@ -1,0 +1,81 @@
+"""Derived tenancy: own tenant wins; blank falls back up the parent chain.
+
+Mirrors NetBox core's VRF/prefix display fallback. Regression tests for
+issue #77.
+"""
+
+import pytest
+from django.contrib.gis.geos import LineString, Point
+from tenancy.models import Tenant
+
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import Conduit, ConduitBank, Innerduct, Structure
+
+SRID = get_srid()
+
+
+@pytest.fixture
+def tenants(db):
+    owner = Tenant.objects.create(name="Owner Co", slug="owner-co")
+    override = Tenant.objects.create(name="Override Co", slug="override-co")
+    return owner, override
+
+
+@pytest.fixture
+def bank(db, tenants):
+    owner, _ = tenants
+    s1 = Structure.objects.create(name="ET-S1", geometry=Point(0, 0, srid=SRID))
+    s2 = Structure.objects.create(name="ET-S2", geometry=Point(100, 100, srid=SRID))
+    bank = ConduitBank(
+        label="ET-BANK",
+        path=LineString((0, 0), (100, 100), srid=SRID),
+        start_structure=s1,
+        end_structure=s2,
+        tenant=owner,
+    )
+    bank.save()
+    return bank
+
+
+@pytest.mark.django_db
+class TestEffectiveTenant:
+    def test_conduit_own_tenant_wins(self, bank, tenants):
+        _, override = tenants
+        conduit = Conduit(label="ET-C1", conduit_bank=bank, tenant=override)
+        conduit.save()
+        assert conduit.effective_tenant == override
+
+    def test_conduit_falls_back_to_bank(self, bank, tenants):
+        owner, _ = tenants
+        conduit = Conduit(label="ET-C2", conduit_bank=bank)
+        conduit.save()
+        assert conduit.tenant is None
+        assert conduit.effective_tenant == owner
+
+    def test_standalone_conduit_without_tenant_is_none(self, db):
+        s1 = Structure.objects.create(name="ET-S3", geometry=Point(0, 0, srid=SRID))
+        s2 = Structure.objects.create(name="ET-S4", geometry=Point(1, 1, srid=SRID))
+        conduit = Conduit(
+            label="ET-C3",
+            path=LineString((0, 0), (1, 1), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        conduit.save()
+        assert conduit.effective_tenant is None
+
+    def test_innerduct_chains_to_bank(self, bank, tenants):
+        owner, _ = tenants
+        conduit = Conduit(label="ET-C4", conduit_bank=bank)
+        conduit.save()
+        duct = Innerduct(label="ET-I1", parent_conduit=conduit, size="32mm")
+        duct.save()
+        assert duct.effective_tenant == owner
+
+    def test_innerduct_own_tenant_wins(self, bank, tenants):
+        _, override = tenants
+        conduit = Conduit(label="ET-C5", conduit_bank=bank)
+        conduit.save()
+        duct = Innerduct(label="ET-I2", parent_conduit=conduit, size="32mm", tenant=override)
+        duct.save()
+        assert duct.effective_tenant == override

--- a/tests/test_endpoint_validation.py
+++ b/tests/test_endpoint_validation.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 
 from netbox_pathways.forms import ConduitBankForm, PathwayForm, PathwaysMapWidget
 from netbox_pathways.geo import get_srid, to_leaflet
-from netbox_pathways.models import Conduit, ConduitJunction, Pathway, Structure
+from netbox_pathways.models import Conduit, ConduitBank, ConduitJunction, Innerduct, Pathway, Structure
 
 SRID = get_srid()
 
@@ -335,3 +335,52 @@ class TestEndToEndFormSave:
         assert obj.path.coords[0] == (100.0, 200.0)
         assert obj.path.coords[-1] == (500.0, 600.0)
         assert len(obj.path.coords) == 3
+
+
+@pytest.mark.django_db
+class TestContainedPathRequirement:
+    """Contained pathways follow their parent's geometry and need no path.
+
+    Regression tests for issue #77.
+    """
+
+    def _bank(self):
+        s1 = _make_structure("BK-S1", Point(0, 0, srid=SRID))
+        s2 = _make_structure("BK-S2", Point(100, 100, srid=SRID))
+        bank = ConduitBank(
+            label="BANK-1",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        bank.save()
+        return bank, s1, s2
+
+    def test_bank_conduit_without_path_is_valid(self):
+        bank, s1, s2 = self._bank()
+        conduit = Conduit(
+            label="C-1",
+            conduit_bank=bank,
+            start_structure=s1,
+            end_structure=s2,
+        )
+        conduit.clean()  # must not raise
+
+    def test_standalone_conduit_without_path_raises(self):
+        s1 = _make_structure("SA-S1", Point(0, 0, srid=SRID))
+        s2 = _make_structure("SA-S2", Point(100, 100, srid=SRID))
+        conduit = Conduit(label="C-2", start_structure=s1, end_structure=s2)
+        with pytest.raises(ValidationError, match="[Pp]ath"):
+            conduit.clean()
+
+    def test_innerduct_without_path_is_valid(self):
+        bank, s1, s2 = self._bank()
+        parent = Conduit(
+            label="C-3",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        parent.save()
+        duct = Innerduct(label="ID-1", parent_conduit=parent, size="32mm")
+        duct.clean()  # inherits endpoints from parent; must not raise

--- a/tests/test_endpoint_validation.py
+++ b/tests/test_endpoint_validation.py
@@ -24,6 +24,19 @@ def _make_pathway(path, start_structure=None, end_structure=None, **kwargs):
     return pw
 
 
+def _make_bank(prefix):
+    s1 = _make_structure(f"{prefix}-S1", Point(0, 0, srid=SRID))
+    s2 = _make_structure(f"{prefix}-S2", Point(100, 100, srid=SRID))
+    bank = ConduitBank(
+        label=f"BANK-{prefix}",
+        path=LineString((0, 0), (100, 100), srid=SRID),
+        start_structure=s1,
+        end_structure=s2,
+    )
+    bank.save()
+    return bank, s1, s2
+
+
 @pytest.mark.django_db
 class TestPathwayEndpointValidation:
     def test_point_structure_within_tolerance_snaps(self):
@@ -345,16 +358,7 @@ class TestContainedPathRequirement:
     """
 
     def _bank(self):
-        s1 = _make_structure("BK-S1", Point(0, 0, srid=SRID))
-        s2 = _make_structure("BK-S2", Point(100, 100, srid=SRID))
-        bank = ConduitBank(
-            label="BANK-1",
-            path=LineString((0, 0), (100, 100), srid=SRID),
-            start_structure=s1,
-            end_structure=s2,
-        )
-        bank.save()
-        return bank, s1, s2
+        return _make_bank("BK")
 
     def test_bank_conduit_without_path_is_valid(self):
         bank, s1, s2 = self._bank()
@@ -392,16 +396,7 @@ class TestConduitBankEndpointInheritance:
     from their parent conduit. Regression tests for issue #77."""
 
     def _bank(self):
-        s1 = _make_structure("BI-S1", Point(0, 0, srid=SRID))
-        s2 = _make_structure("BI-S2", Point(100, 100, srid=SRID))
-        bank = ConduitBank(
-            label="BANK-2",
-            path=LineString((0, 0), (100, 100), srid=SRID),
-            start_structure=s1,
-            end_structure=s2,
-        )
-        bank.save()
-        return bank, s1, s2
+        return _make_bank("BI")
 
     def test_blank_endpoints_inherit_from_bank_on_clean(self):
         bank, s1, s2 = self._bank()

--- a/tests/test_endpoint_validation.py
+++ b/tests/test_endpoint_validation.py
@@ -384,3 +384,73 @@ class TestContainedPathRequirement:
         parent.save()
         duct = Innerduct(label="ID-1", parent_conduit=parent, size="32mm")
         duct.clean()  # inherits endpoints from parent; must not raise
+
+
+@pytest.mark.django_db
+class TestConduitBankEndpointInheritance:
+    """Blank conduit endpoints inherit from the bank, like innerducts do
+    from their parent conduit. Regression tests for issue #77."""
+
+    def _bank(self):
+        s1 = _make_structure("BI-S1", Point(0, 0, srid=SRID))
+        s2 = _make_structure("BI-S2", Point(100, 100, srid=SRID))
+        bank = ConduitBank(
+            label="BANK-2",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        bank.save()
+        return bank, s1, s2
+
+    def test_blank_endpoints_inherit_from_bank_on_clean(self):
+        bank, s1, s2 = self._bank()
+        conduit = Conduit(label="C-10", conduit_bank=bank)
+        conduit.clean()
+        assert conduit.start_structure == s1
+        assert conduit.end_structure == s2
+
+    def test_save_persists_inherited_endpoints(self):
+        bank, s1, s2 = self._bank()
+        conduit = Conduit(label="C-11", conduit_bank=bank)
+        conduit.save()
+        conduit.refresh_from_db()
+        assert conduit.start_structure == s1
+        assert conduit.end_structure == s2
+
+    def test_explicit_endpoint_side_is_not_overridden(self):
+        bank, s1, s2 = self._bank()
+        other = _make_structure("BI-S3", Point(0, 0.5, srid=SRID))
+        conduit = Conduit(label="C-12", conduit_bank=bank, start_structure=other)
+        conduit.clean()
+        assert conduit.start_structure == other
+        assert conduit.end_structure == s2
+
+    def test_junction_side_is_not_touched(self):
+        bank, s1, s2 = self._bank()
+        trunk = Conduit(
+            label="TRUNK",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        trunk.save()
+        branch = Conduit(label="BRANCH", conduit_bank=bank)
+        branch.save()
+        junction = ConduitJunction.objects.create(
+            trunk_conduit=trunk,
+            branch_conduit=branch,
+            towards_structure=s2,
+            position_on_trunk=0.5,
+        )
+        conduit = Conduit(label="C-13", conduit_bank=bank, start_junction=junction)
+        conduit.clean()
+        assert conduit.start_structure is None
+        assert conduit.start_location is None
+        assert conduit.end_structure == s2
+
+    def test_bankless_blank_endpoints_still_invalid(self):
+        path = LineString((0, 0), (100, 100), srid=SRID)
+        conduit = Conduit(label="C-14", path=path)
+        with pytest.raises(ValidationError, match="start point"):
+            conduit.clean()

--- a/tests/test_form_prefill.py
+++ b/tests/test_form_prefill.py
@@ -43,6 +43,8 @@ def bank(db):
 class TestConduitFormPrefill:
     def test_prefills_from_bank_pk(self, bank):
         form = ConduitForm(initial={"conduit_bank": str(bank.pk)})
+        assert "start_face" in form.fields
+        assert "end_face" in form.fields
         assert form.initial["start_structure"] == bank.start_structure.pk
         assert form.initial["end_structure"] == bank.end_structure.pk
         assert form.initial["start_face"] == "north"
@@ -72,7 +74,8 @@ class TestConduitFormPrefill:
         conduit = Conduit(label="PF-C1", conduit_bank=bank)
         conduit.save()
         form = ConduitForm(instance=conduit, initial={"conduit_bank": str(bank.pk)})
-        assert "start_face" not in form.initial
+        assert form.initial["start_face"] != bank.start_face
+        assert form.initial["end_face"] != bank.end_face
 
 
 @pytest.mark.django_db

--- a/tests/test_form_prefill.py
+++ b/tests/test_form_prefill.py
@@ -1,0 +1,96 @@
+"""Create-form prefill from a parent object passed via initial data.
+
+The Add buttons on the parent detail pages link to the child create form
+with ?conduit_bank=<pk> / ?parent_conduit=<pk>; the form expands that
+single parameter into visible initial values. Regression tests for
+issue #77.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.gis.geos import LineString, Point
+from tenancy.models import Tenant
+
+from netbox_pathways.forms import ConduitForm, InnerductForm
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import Conduit, ConduitBank, Structure
+
+SRID = get_srid()
+
+
+@pytest.fixture
+def bank(db):
+    s1 = Structure.objects.create(name="PF-S1", geometry=Point(0, 0, srid=SRID))
+    s2 = Structure.objects.create(name="PF-S2", geometry=Point(100, 100, srid=SRID))
+    installer = Tenant.objects.create(name="Installer Inc", slug="installer-inc")
+    bank = ConduitBank(
+        label="PF-BANK",
+        path=LineString((0, 0), (100, 100), srid=SRID),
+        start_structure=s1,
+        end_structure=s2,
+        start_face="north",
+        end_face="south",
+        installed_by=installer,
+        installation_date=datetime.date(2025, 6, 1),
+        commissioned_date=datetime.date(2025, 7, 1),
+    )
+    bank.save()
+    return bank
+
+
+@pytest.mark.django_db
+class TestConduitFormPrefill:
+    def test_prefills_from_bank_pk(self, bank):
+        form = ConduitForm(initial={"conduit_bank": str(bank.pk)})
+        assert form.initial["start_structure"] == bank.start_structure.pk
+        assert form.initial["end_structure"] == bank.end_structure.pk
+        assert form.initial["start_face"] == "north"
+        assert form.initial["end_face"] == "south"
+        assert form.initial["installed_by"] == bank.installed_by.pk
+        assert form.initial["installation_date"] == datetime.date(2025, 6, 1)
+        assert form.initial["commissioned_date"] == datetime.date(2025, 7, 1)
+
+    def test_never_prefills_path_or_tenant(self, bank):
+        form = ConduitForm(initial={"conduit_bank": str(bank.pk)})
+        assert "path" not in form.initial
+        assert "tenant" not in form.initial
+
+    def test_explicit_initial_wins(self, bank):
+        other = Structure.objects.create(name="PF-S3", geometry=Point(50, 50, srid=SRID))
+        form = ConduitForm(initial={"conduit_bank": str(bank.pk), "start_structure": str(other.pk)})
+        assert form.initial["start_structure"] == str(other.pk)
+        assert form.initial["end_structure"] == bank.end_structure.pk
+
+    def test_bogus_pk_is_ignored(self, db):
+        form = ConduitForm(initial={"conduit_bank": "999999"})
+        assert "start_structure" not in form.initial
+        form = ConduitForm(initial={"conduit_bank": "not-a-pk"})
+        assert "start_structure" not in form.initial
+
+    def test_editing_existing_conduit_never_prefills(self, bank):
+        conduit = Conduit(label="PF-C1", conduit_bank=bank)
+        conduit.save()
+        form = ConduitForm(instance=conduit, initial={"conduit_bank": str(bank.pk)})
+        assert "start_face" not in form.initial
+
+
+@pytest.mark.django_db
+class TestInnerductFormPrefill:
+    def test_prefills_endpoints_only(self, bank):
+        parent = Conduit(
+            label="PF-C2",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=bank.start_structure,
+            end_structure=bank.end_structure,
+            installed_by=bank.installed_by,
+            installation_date=datetime.date(2025, 6, 2),
+        )
+        parent.save()
+        form = InnerductForm(initial={"parent_conduit": str(parent.pk)})
+        assert form.initial["start_structure"] == parent.start_structure.pk
+        assert form.initial["end_structure"] == parent.end_structure.pk
+        # lifecycle fields are never inherited by innerducts
+        assert "installed_by" not in form.initial
+        assert "installation_date" not in form.initial
+        assert "commissioned_date" not in form.initial

--- a/tests/test_pathway_endpoint_form_mixin.py
+++ b/tests/test_pathway_endpoint_form_mixin.py
@@ -5,7 +5,7 @@ from django.contrib.gis.geos import LineString, Point, Polygon
 
 from netbox_pathways.forms import ConduitForm, InnerductForm
 from netbox_pathways.geo import get_srid, to_leaflet
-from netbox_pathways.models import Conduit, Structure
+from netbox_pathways.models import Conduit, ConduitBank, Structure
 
 SRID = get_srid()
 
@@ -69,9 +69,10 @@ class TestPathwayEndpointFormMixinClean:
         # centroid of the square (0,0)-(10,10) is (5, 5)
         assert start_pt == (5.0, 5.0)
 
-    def test_innerduct_inherits_parent_conduit_structures(self):
-        """Innerduct fallback: when structures are omitted, inherit from
-        parent_conduit's start/end."""
+    def test_innerduct_gets_no_synthetic_path(self):
+        """Contained pathways own no geometry: an innerduct with a blank path
+        stays pathless instead of receiving a straight line between the
+        parent's structures. Behavior change for issue #77."""
         s1 = _make_structure("S1", Point(0, 0, srid=SRID))
         s2 = _make_structure("S2", Point(100, 100, srid=SRID))
         parent = Conduit(
@@ -91,7 +92,29 @@ class TestPathwayEndpointFormMixinClean:
             }
         )
         assert form.is_valid(), form.errors
-        assert form.cleaned_data["path"] is not None
+        assert form.cleaned_data["path"] is None
+
+    def test_bank_conduit_gets_no_synthetic_path(self):
+        """A conduit created inside a bank stays pathless: the bank owns the
+        route geometry. Behavior change for issue #77."""
+        s1 = _make_structure("S1", Point(0, 0, srid=SRID))
+        s2 = _make_structure("S2", Point(100, 100, srid=SRID))
+        bank = ConduitBank(
+            label="BANK-1",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        bank.save()
+        form = ConduitForm(
+            data={
+                "status": "active",
+                "conduit_bank": bank.pk,
+                "tags": [],
+            }
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["path"] is None
 
     def test_no_path_no_structures_raises_validation_error(self):
         """Without a path and without structures, the mixin must reject."""


### PR DESCRIPTION
## Summary
- Adds an "Add" button to the Conduits panel on a conduit bank's detail page and to the Innerducts panel on a conduit's detail page; each opens the child create form pre-filled from the parent, ending the two-tab copy-paste workflow.
- Bank conduits gain model-level endpoint inheritance (blank endpoints inherit from the bank at clean/save, mirroring the existing innerduct pattern), and contained pathways (bank conduits, innerducts) no longer require -- or receive a synthetic -- path geometry: the parent owns the route.
- Tenancy is derived NetBox-style: new `effective_tenant` properties back a tenant table column that falls back to the parent chain's tenant, marked with a trailing `*` (core `TenantColumn` convention). Detail panels and filtering keep using the stored field, as in core.

## Changes
- `netbox_pathways/views.py`: `ui_actions.AddObject` panel actions on the two parent detail layouts; `select_related` additions so the tenant fallback column stays N+1-free.
- `netbox_pathways/forms.py`: `_resolve_initial_parent` / `_prefill_initial_from_parent` helpers; `ConduitForm` prefills endpoints, faces, installed-by and dates from `?conduit_bank=<pk>` (and now exposes `start_face`/`end_face`); `InnerductForm` prefills endpoints only from `?parent_conduit=<pk>` (lifecycle fields are never inherited); `PathwayPathFallbackMixin` early-returns for contained rows; implied "leave blank to inherit" help texts dropped (core precedent: tenancy inheritance carries no help text).
- `netbox_pathways/models.py`: shared `Pathway._inherit_endpoints_from()` helper used by `Conduit._inherit_bank_endpoints()` (new) and `Innerduct._inherit_parent_endpoints()` (refactored); `requires_path` property (Pathway/Conduit/Innerduct overrides); `effective_tenant` on Conduit and Innerduct.
- `netbox_pathways/tables.py`: shared `_TENANT_COLUMN` template constant; tenant columns on `ConduitTable` and `InnerductTable` (not in default columns).
- `tests/`: new `test_form_prefill.py` and `test_effective_tenant.py`; contained-path and bank-inheritance classes in `test_endpoint_validation.py`; mixin tests updated for the no-synthetic-path rule.
- `CHANGELOG.md`, `docs/user-guide/conduit-banks.md`, `docs/user-guide/pathways.md`: user-facing documentation.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (654 passed, coverage 80.54% -- matches main's 80.55%)
- [x] New/changed behavior covered by tests (model inheritance, path rules, form prefill, effective_tenant)
- [x] Migration applied cleanly (n/a -- no schema change)
- [x] Docs updated (CHANGELOG, conduit-banks and pathways user guides)

## Screenshots / output
The Add buttons render in the panel headers of the existing Conduits / Innerducts tables (standard NetBox `AddObject` panel action, permission-gated).

## Related
Fixes #77
