### PR TITLE
chore(ci): let Renovate bump NetBox matrix patch releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,11 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.5.10", "4.6.7"]
+        netbox:
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.5.10"
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.6.7"
     services:
       postgres:
         image: postgis/postgis:17-3.4
@@ -185,7 +189,7 @@ jobs:
           pytest tests/ -v --tb=short --cov=netbox_pathways --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && matrix.netbox == '4.5.10'
+        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.5.')
         continue-on-error: true
         uses: codecov/codecov-action@v7
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,29 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.5\\./",
+      "allowedVersions": "/^4\\.5\\./"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.6\\./",
+      "allowedVersions": "/^4\\.6\\./"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/ci\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+- \"(?<currentValue>[^\"]+)\""
+      ],
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Follow-up to #118: the NetBox versions in the CI matrix were opaque strings that Renovate could not see, so patch bumps were manual.
- Adds a custom regex manager so Renovate tracks both matrix entries against netbox-community/netbox GitHub releases, with each entry pinned to its minor train (4.5.x / 4.6.x) so only patch bumps are proposed. The existing non-major automerge rule applies to them.
- Makes the Codecov upload condition prefix-based so a future 4.5.x patch bump cannot silently stop coverage uploads (it previously pinned the exact string 4.5.10).

## Changes
- .github/workflows/ci.yml: matrix entries become an annotated block list (semantically identical); Codecov condition matches startsWith(matrix.netbox, '4.5.')
- renovate.json: customManagers regex entry (github-releases datasource, v-prefix stripped via extractVersionTemplate); two packageRules pin each entry to its minor train via matchCurrentValue + allowedVersions

## Testing
- [x] renovate-config-validator passes
- [x] Renovate --platform=local dry-run: both entries extracted; with entries downgraded to 4.5.8/4.6.3 it offers exactly 4.5.10 and 4.6.7 as patch updates and does not offer the cross-minor 4.5.8 -> 4.6.7 jump; with current values it offers no updates
- [x] YAML parse confirms the matrix is semantically unchanged
- [x] CI matrix green on this PR

## Related
Refs: #118