### PR TITLE
feat(models): populate clone_fields so Clone pre-fills create forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carries over status, endpoints, tenant, installer, dates, and
   type-specific attributes. Identity and geometry fields (name, label,
   path, geometry, bank position, innerduct position, a structure's
-  location link) are deliberately never cloned. Refs #120.
+  elevation and location link) are deliberately never cloned. Refs #120.
 
 - **Add-child buttons that inherit the parent's attributes.** The Conduits
   panel on a conduit bank and the Innerducts panel on a conduit now carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Clone pre-fills the create form.** All seven clonable models
+  (Structure, Pathway, Conduit Bank, Conduit, Aerial Span, Direct
+  Buried, Innerduct) now declare `clone_fields`, so the Clone button
+  carries over status, endpoints, tenant, installer, dates, and
+  type-specific attributes. Identity and geometry fields (name, label,
+  path, geometry, bank position, innerduct position, a structure's
+  location link) are deliberately never cloned. Refs #120.
+
 - **Add-child buttons that inherit the parent's attributes.** The Conduits
   panel on a conduit bank and the Innerducts panel on a conduit now carry
   an "Add" button that opens the create form pre-filled from the parent:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Clone pre-fills the create form.** All seven clonable models
   (Structure, Pathway, Conduit Bank, Conduit, Aerial Span, Direct
   Buried, Innerduct) now declare `clone_fields`, so the Clone button
-  carries over status, endpoints, tenant, installer, dates, and
-  type-specific attributes. Identity and geometry fields (name, label,
-  path, geometry, bank position, innerduct position, a structure's
-  elevation and location link) are deliberately never cloned. Refs #120.
+  carries over status, endpoints, installer, dates, and type-specific
+  attributes. Identity and geometry fields (name, label, path, geometry,
+  bank position, innerduct position, a structure's elevation and location
+  link) are deliberately never cloned. Refs #120.
 
 - **Add-child buttons that inherit the parent's attributes.** The Conduits
   panel on a conduit bank and the Innerducts panel on a conduit now carry

--- a/docs/user-guide/pathways.md
+++ b/docs/user-guide/pathways.md
@@ -162,3 +162,13 @@ Pathway lists support filtering by:
 ## Intermediate Locations
 
 Pathways can pass through intermediate locations (sites or rooms) along their route. Use **Pathway Locations** to record these waypoints with sequence numbers for ordering. This is useful for documenting that a conduit passes through multiple manholes along its route.
+
+## Cloning
+
+Every pathway detail view has a Clone button. Cloning pre-fills the
+create form with the source object's status, endpoints, tenant,
+installer, dates, and type-specific attributes (faces and bank for
+conduits, span attributes for aerial spans, burial attributes for
+direct-buried runs, parent conduit, size, and color for innerducts).
+The route geometry, label, and per-parent positions are never copied,
+so you can document parallel runs quickly and then draw each path.

--- a/docs/user-guide/pathways.md
+++ b/docs/user-guide/pathways.md
@@ -166,9 +166,9 @@ Pathways can pass through intermediate locations (sites or rooms) along their ro
 ## Cloning
 
 Every pathway detail view has a Clone button. Cloning pre-fills the
-create form with the source object's status, endpoints, tenant,
-installer, dates, and type-specific attributes (faces and bank for
-conduits, span attributes for aerial spans, burial attributes for
-direct-buried runs, parent conduit, size, and color for innerducts).
-The route geometry, label, and per-parent positions are never copied,
-so you can document parallel runs quickly and then draw each path.
+create form with the source object's status, endpoints, installer,
+dates, and type-specific attributes (faces and bank for conduits, span
+attributes for aerial spans, burial attributes for direct-buried runs,
+parent conduit, size, and color for innerducts). The route geometry,
+label, and per-parent positions are never copied, so you can document
+parallel runs quickly and then draw each path.

--- a/docs/user-guide/structures.md
+++ b/docs/user-guide/structures.md
@@ -106,3 +106,10 @@ The structure list view supports bulk editing and deletion. Select multiple stru
 - Change structure type
 - Assign a tenant
 - Delete selected structures
+
+## Cloning
+
+The Clone button on a structure pre-fills a new create form with the
+source structure's status, type, site, tenant, installer, dates, and
+dimensions. The name, geometry, elevation, and linked NetBox location
+are never copied, since those identify the original structure.

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -315,6 +315,18 @@ class Pathway(NetBoxModel):
     )
     comments = models.TextField(blank=True)
 
+    clone_fields = (
+        "status",
+        "start_structure",
+        "end_structure",
+        "start_location",
+        "end_location",
+        "tenant",
+        "installed_by",
+        "installation_date",
+        "commissioned_date",
+    )
+
     class Meta:
         ordering = ["pk"]
         indexes = [
@@ -711,6 +723,16 @@ class AerialSpan(Pathway):
     wind_loading = models.CharField(max_length=50, blank=True, help_text="Wind loading zone/rating")
     ice_loading = models.CharField(max_length=50, blank=True, help_text="Ice loading zone/rating")
 
+    clone_fields = Pathway.clone_fields + (
+        "aerial_type",
+        "start_attachment_height",
+        "end_attachment_height",
+        "sag",
+        "messenger_size",
+        "wind_loading",
+        "ice_loading",
+    )
+
     class Meta:
         verbose_name = "Aerial Span"
         verbose_name_plural = "Aerial Spans"
@@ -744,6 +766,13 @@ class DirectBuried(Pathway):
     warning_tape = models.BooleanField(default=False, help_text="Warning tape installed above cable")
     tracer_wire = models.BooleanField(default=False, help_text="Tracer wire installed with cable")
     armor_type = models.CharField(max_length=100, blank=True, help_text="Cable armor type if applicable")
+
+    clone_fields = Pathway.clone_fields + (
+        "burial_depth",
+        "warning_tape",
+        "tracer_wire",
+        "armor_type",
+    )
 
     class Meta:
         verbose_name = "Direct Buried"

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -85,6 +85,20 @@ class Structure(NetBoxModel):
     access_notes = models.TextField(blank=True, help_text="Access restrictions or requirements")
     comments = models.TextField(blank=True)
 
+    clone_fields = (
+        "status",
+        "structure_type",
+        "site",
+        "tenant",
+        "installed_by",
+        "installation_date",
+        "commissioned_date",
+        "height",
+        "width",
+        "length",
+        "depth",
+    )
+
     class Meta:
         ordering = ["name"]
         indexes = [

--- a/netbox_pathways/models.py
+++ b/netbox_pathways/models.py
@@ -555,6 +555,16 @@ class ConduitBank(Pathway):
     )
     encasement_type = models.CharField(max_length=50, choices=EncasementTypeChoices, blank=True)
 
+    clone_fields = Pathway.clone_fields + (
+        "start_face",
+        "end_face",
+        "configuration",
+        "total_conduits",
+        "height",
+        "width",
+        "encasement_type",
+    )
+
     class Meta:
         verbose_name = "Conduit Bank"
         verbose_name_plural = "Conduit Banks"
@@ -642,6 +652,18 @@ class Conduit(Pathway):
     def is_indoor(self):
         """Junction endpoints are geographic, so they also preclude indoor status."""
         return super().is_indoor and not self.start_junction_id and not self.end_junction_id
+
+    clone_fields = Pathway.clone_fields + (
+        "start_face",
+        "end_face",
+        "material",
+        "inner_diameter",
+        "outer_diameter",
+        "depth",
+        "conduit_bank",
+        "start_junction",
+        "end_junction",
+    )
 
     class Meta:
         verbose_name = "Conduit"
@@ -812,6 +834,12 @@ class Innerduct(Pathway):
     size = models.CharField(max_length=50, help_text='Innerduct size (e.g., 1.25", 32mm)')
     color = ColorField(blank=True, help_text="Innerduct color for identification")
     position = models.CharField(max_length=50, blank=True, help_text="Position within parent conduit")
+
+    clone_fields = Pathway.clone_fields + (
+        "parent_conduit",
+        "size",
+        "color",
+    )
 
     class Meta:
         verbose_name = "Innerduct"

--- a/tests/test_clone_fields.py
+++ b/tests/test_clone_fields.py
@@ -114,8 +114,6 @@ class TestDirectBuriedClone:
         assert attrs["warning_tape"] is True
         assert attrs["armor_type"] == "interlocked steel"
         assert attrs["start_structure"] == s1.pk
-        assert "label" not in attrs
-        assert "path" not in attrs
 
 
 @pytest.mark.django_db
@@ -145,8 +143,6 @@ class TestConduitBankClone:
         assert attrs["width"] == 900
         assert attrs["encasement_type"] == "concrete"
         assert attrs["start_structure"] == s1.pk
-        assert "label" not in attrs
-        assert "path" not in attrs
 
 
 @pytest.mark.django_db
@@ -180,8 +176,6 @@ class TestConduitClone:
         assert attrs["inner_diameter"] == 94.0
         assert attrs["outer_diameter"] == 110.0
         assert attrs["depth"] == 1.1
-        assert "bank_position" not in attrs
-        assert "label" not in attrs
 
     def test_junction_endpoints_are_clonable(self):
         assert "start_junction" in Conduit.clone_fields
@@ -211,8 +205,6 @@ class TestInnerductClone:
         assert attrs["parent_conduit"] == parent.pk
         assert attrs["size"] == "32mm"
         assert attrs["color"] == "ff9800"
-        assert "position" not in attrs
-        assert "label" not in attrs
 
 
 @pytest.mark.django_db
@@ -244,10 +236,6 @@ class TestStructureClone:
         assert attrs["width"] == 0.6
         assert attrs["length"] == 1.2
         assert attrs["depth"] == 0.9
-        assert "name" not in attrs
-        assert "geometry" not in attrs
-        assert "elevation" not in attrs
-        assert "location" not in attrs
 
 
 ALL_CLONABLE_MODELS = [
@@ -260,7 +248,16 @@ ALL_CLONABLE_MODELS = [
     Innerduct,
 ]
 
-NEVER_CLONED = {"path", "geometry", "location", "name", "label", "bank_position", "position"}
+NEVER_CLONED = {
+    "path",
+    "geometry",
+    "location",
+    "name",
+    "label",
+    "bank_position",
+    "position",
+    "elevation",
+}
 
 
 @pytest.mark.parametrize("model", ALL_CLONABLE_MODELS)

--- a/tests/test_clone_fields.py
+++ b/tests/test_clone_fields.py
@@ -11,7 +11,14 @@ from django.contrib.gis.geos import LineString, Point
 from tenancy.models import Tenant
 
 from netbox_pathways.geo import get_srid
-from netbox_pathways.models import AerialSpan, DirectBuried, Structure
+from netbox_pathways.models import (
+    AerialSpan,
+    Conduit,
+    ConduitBank,
+    DirectBuried,
+    Innerduct,
+    Structure,
+)
 
 SRID = get_srid()
 
@@ -108,3 +115,100 @@ class TestDirectBuriedClone:
         assert attrs["start_structure"] == s1.pk
         assert "label" not in attrs
         assert "path" not in attrs
+
+
+@pytest.mark.django_db
+class TestConduitBankClone:
+    def test_clone_carries_bank_attributes(self, endpoints):
+        s1, s2 = endpoints
+        bank = ConduitBank(
+            label="CF-BANK1",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+            start_face="north",
+            end_face="south",
+            configuration="2x3",
+            total_conduits=6,
+            height=600,
+            width=900,
+            encasement_type="concrete",
+        )
+        bank.save()
+        attrs = bank.clone()
+        assert attrs["start_face"] == "north"
+        assert attrs["end_face"] == "south"
+        assert attrs["configuration"] == "2x3"
+        assert attrs["total_conduits"] == 6
+        assert attrs["height"] == 600
+        assert attrs["width"] == 900
+        assert attrs["encasement_type"] == "concrete"
+        assert attrs["start_structure"] == s1.pk
+        assert "label" not in attrs
+        assert "path" not in attrs
+
+
+@pytest.mark.django_db
+class TestConduitClone:
+    def test_clone_carries_bank_membership_and_attributes(self, endpoints):
+        s1, s2 = endpoints
+        bank = ConduitBank(
+            label="CF-BANK2",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        bank.save()
+        conduit = Conduit(
+            label="CF-C1",
+            conduit_bank=bank,
+            bank_position="A1",
+            start_face="east",
+            end_face="west",
+            material="hdpe",
+            inner_diameter=94.0,
+            outer_diameter=110.0,
+            depth=1.1,
+        )
+        conduit.save()
+        attrs = conduit.clone()
+        assert attrs["conduit_bank"] == bank.pk
+        assert attrs["start_face"] == "east"
+        assert attrs["end_face"] == "west"
+        assert attrs["material"] == "hdpe"
+        assert attrs["inner_diameter"] == 94.0
+        assert attrs["outer_diameter"] == 110.0
+        assert attrs["depth"] == 1.1
+        assert "bank_position" not in attrs
+        assert "label" not in attrs
+
+    def test_junction_endpoints_are_clonable(self):
+        assert "start_junction" in Conduit.clone_fields
+        assert "end_junction" in Conduit.clone_fields
+
+
+@pytest.mark.django_db
+class TestInnerductClone:
+    def test_clone_carries_parent_size_and_color(self, endpoints):
+        s1, s2 = endpoints
+        parent = Conduit(
+            label="CF-C2",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        parent.save()
+        duct = Innerduct(
+            label="CF-ID1",
+            parent_conduit=parent,
+            size="32mm",
+            color="ff9800",
+            position="1",
+        )
+        duct.save()
+        attrs = duct.clone()
+        assert attrs["parent_conduit"] == parent.pk
+        assert attrs["size"] == "32mm"
+        assert attrs["color"] == "ff9800"
+        assert "position" not in attrs
+        assert "label" not in attrs

--- a/tests/test_clone_fields.py
+++ b/tests/test_clone_fields.py
@@ -1,0 +1,110 @@
+"""Clone action pre-fill: per-model clone_fields declarations.
+
+Regression tests for issue #120: no model defined clone_fields, so every
+Clone button opened an essentially empty create form.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.gis.geos import LineString, Point
+from tenancy.models import Tenant
+
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import AerialSpan, DirectBuried, Structure
+
+SRID = get_srid()
+
+
+@pytest.fixture
+def endpoints(db):
+    s1 = Structure.objects.create(name="CF-S1", geometry=Point(0, 0, srid=SRID))
+    s2 = Structure.objects.create(name="CF-S2", geometry=Point(100, 100, srid=SRID))
+    return s1, s2
+
+
+@pytest.fixture
+def tenant(db):
+    return Tenant.objects.create(name="CF Tenant", slug="cf-tenant")
+
+
+@pytest.fixture
+def installer(db):
+    return Tenant.objects.create(name="CF Installer", slug="cf-installer")
+
+
+@pytest.mark.django_db
+class TestAerialSpanClone:
+    def test_clone_carries_base_and_span_attributes(self, endpoints, tenant, installer):
+        s1, s2 = endpoints
+        span = AerialSpan(
+            label="CF-AS1",
+            status="active",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+            tenant=tenant,
+            installed_by=installer,
+            installation_date=datetime.date(2025, 6, 1),
+            commissioned_date=datetime.date(2025, 7, 1),
+            aerial_type="lashed",
+            start_attachment_height=6.5,
+            end_attachment_height=6.0,
+            sag=0.4,
+            messenger_size="6M",
+            wind_loading="B",
+            ice_loading="medium",
+        )
+        span.save()
+        attrs = span.clone()
+        assert attrs["status"] == "active"
+        assert attrs["start_structure"] == s1.pk
+        assert attrs["end_structure"] == s2.pk
+        assert attrs["tenant"] == tenant.pk
+        assert attrs["installed_by"] == installer.pk
+        assert attrs["installation_date"] == datetime.date(2025, 6, 1)
+        assert attrs["commissioned_date"] == datetime.date(2025, 7, 1)
+        assert attrs["aerial_type"] == "lashed"
+        assert attrs["start_attachment_height"] == 6.5
+        assert attrs["end_attachment_height"] == 6.0
+        assert attrs["sag"] == 0.4
+        assert attrs["messenger_size"] == "6M"
+        assert attrs["wind_loading"] == "B"
+        assert attrs["ice_loading"] == "medium"
+
+    def test_clone_never_carries_identity_or_geometry(self, endpoints):
+        s1, s2 = endpoints
+        span = AerialSpan(
+            label="CF-AS2",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        span.save()
+        attrs = span.clone()
+        assert "label" not in attrs
+        assert "path" not in attrs
+        assert "length" not in attrs
+
+
+@pytest.mark.django_db
+class TestDirectBuriedClone:
+    def test_clone_carries_burial_attributes(self, endpoints):
+        s1, s2 = endpoints
+        run = DirectBuried(
+            label="CF-DB1",
+            path=LineString((0, 0), (100, 100), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+            burial_depth=1.2,
+            warning_tape=True,
+            armor_type="interlocked steel",
+        )
+        run.save()
+        attrs = run.clone()
+        assert attrs["burial_depth"] == 1.2
+        assert attrs["warning_tape"] is True
+        assert attrs["armor_type"] == "interlocked steel"
+        assert attrs["start_structure"] == s1.pk
+        assert "label" not in attrs
+        assert "path" not in attrs

--- a/tests/test_clone_fields.py
+++ b/tests/test_clone_fields.py
@@ -17,6 +17,7 @@ from netbox_pathways.models import (
     ConduitBank,
     DirectBuried,
     Innerduct,
+    Pathway,
     Structure,
 )
 
@@ -212,3 +213,68 @@ class TestInnerductClone:
         assert attrs["color"] == "ff9800"
         assert "position" not in attrs
         assert "label" not in attrs
+
+
+@pytest.mark.django_db
+class TestStructureClone:
+    def test_clone_carries_descriptive_fields(self, tenant, installer):
+        structure = Structure.objects.create(
+            name="CF-S10",
+            status="active",
+            structure_type="handhole",
+            geometry=Point(10, 10, srid=SRID),
+            elevation=120.0,
+            height=0.6,
+            width=0.6,
+            length=1.2,
+            depth=0.9,
+            tenant=tenant,
+            installed_by=installer,
+            installation_date=datetime.date(2025, 5, 1),
+            commissioned_date=datetime.date(2025, 5, 15),
+        )
+        attrs = structure.clone()
+        assert attrs["status"] == "active"
+        assert attrs["structure_type"] == "handhole"
+        assert attrs["tenant"] == tenant.pk
+        assert attrs["installed_by"] == installer.pk
+        assert attrs["installation_date"] == datetime.date(2025, 5, 1)
+        assert attrs["commissioned_date"] == datetime.date(2025, 5, 15)
+        assert attrs["height"] == 0.6
+        assert attrs["width"] == 0.6
+        assert attrs["length"] == 1.2
+        assert attrs["depth"] == 0.9
+        assert "name" not in attrs
+        assert "geometry" not in attrs
+        assert "elevation" not in attrs
+        assert "location" not in attrs
+
+
+ALL_CLONABLE_MODELS = [
+    Structure,
+    Pathway,
+    ConduitBank,
+    Conduit,
+    AerialSpan,
+    DirectBuried,
+    Innerduct,
+]
+
+NEVER_CLONED = {"path", "geometry", "location", "name", "label", "bank_position", "position"}
+
+
+@pytest.mark.parametrize("model", ALL_CLONABLE_MODELS)
+def test_identity_and_geometry_fields_never_cloned(model):
+    assert NEVER_CLONED.isdisjoint(model.clone_fields)
+
+
+@pytest.mark.parametrize("model", ALL_CLONABLE_MODELS)
+def test_clone_field_names_resolve(model):
+    for name in model.clone_fields:
+        model._meta.get_field(name)
+
+
+def test_pathway_subclasses_inherit_base_clone_fields():
+    base = set(Pathway.clone_fields)
+    for model in (ConduitBank, Conduit, AerialSpan, DirectBuried, Innerduct):
+        assert base <= set(model.clone_fields)


### PR DESCRIPTION
## Summary
- Declare `clone_fields` on all seven clonable models (Structure, Pathway, ConduitBank, Conduit, AerialSpan, DirectBuried, Innerduct) so the Clone action pre-fills the create form instead of opening it essentially empty.
- Pathway subclasses compose `Pathway.clone_fields + (...)` because NetBox's `CloningMixin` resolves `clone_fields` with plain `getattr` (a subclass declaration replaces the base one).
- Identity and geometry fields are deliberately never cloned: `name`, `label`, `path`, `geometry`, `bank_position`, innerduct `position`, a structure's `elevation` and identity `location` link.

## Changes
- `netbox_pathways/models.py`: `clone_fields` tuples on the seven models; no schema change, no migration.
- `tests/test_clone_fields.py`: per-model `clone()` output tests plus cross-model guards (exclusions enforced, every declared name resolves via `_meta.get_field`,every subclass tuple is a superset of the base).
- `CHANGELOG.md`: entry under `[Unreleased]` / `Added`.
- `docs/user-guide/pathways.md`, `docs/user-guide/structures.md`: short "Cloning" sections.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (679 passed, coverage 80.60% vs 80.57% baseline)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (n/a -- no schema change)
- [x] Docs updated (README n/a, CHANGELOG, zensical pages)

## Notes for review
- Tenant is only listed as carried over where the create form exposes it: `ConduitForm`, `AerialSpanForm`, `DirectBuriedForm`, and `InnerductForm` have no tenant field, so the docs qualify that claim. Normalizing tenant exposure across pathway forms may deserve a follow-up issue.
- Clone parameters flow through the same GET-to-initial path as the #77 add-child buttons; explicit clone parameters win over the parent prefill.

## Related
Fixes #120
