### PR TITLE
fix(api): enforce object permissions on geo endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing and silently listed every pathway instead. The picker now offers
   both endpoints of the previous pathway, and junction endpoints resolve.
 
+### Security
+
+- **The `geo/*` API endpoints ignored object-level permissions.** The
+  GeoJSON viewsets that feed the map and GIS clients served every row of a
+  model to any user holding a view permission on it, disregarding
+  `ObjectPermission` constraints -- on a multi-tenant install, a user
+  restricted to one tenant could see every other tenant's structures,
+  conduit routes, and circuit geometries, in the UI map and the API alike.
+  All seven layer endpoints and the `/info` layer counts now restrict their
+  querysets to the requesting user's permitted objects, exactly as the
+  regular REST endpoints always have. Reported by @Lesnikovsok. Fixes #123.
+
 ## [0.2.2] - 2026-06-30
 
 ### Fixed

--- a/netbox_pathways/api/geo.py
+++ b/netbox_pathways/api/geo.py
@@ -246,7 +246,10 @@ class BboxFilterMixin:
         return qs
 
     def get_queryset(self):
-        qs = super().get_queryset()
+        # Enforce NetBox object-level permissions: without this, any user
+        # holding a constrained view permission on the model would receive
+        # every row, leaking other tenants' plant data through the map.
+        qs = super().get_queryset().restrict(self.request.user, "view")
         qs = _exclude_status(qs, _parse_exclude_status(self.request))
         return self._apply_bbox(qs)
 
@@ -564,7 +567,9 @@ class MapInfoView(APIView):
             return c
 
         for key, model, geo_field, extra_filter in _INFO_LAYERS:
-            qs = model.objects.all()
+            # Same object-permission restriction the layer endpoints apply,
+            # so counts never disclose rows the user cannot see.
+            qs = model.objects.restrict(request.user, "view")
             if extra_filter:
                 qs = qs.filter(**extra_filter)
             qs = _exclude_status(qs, excluded_statuses)

--- a/tests/test_geo_api.py
+++ b/tests/test_geo_api.py
@@ -730,3 +730,76 @@ class TestMapViewSelect:
         with patch.object(view, "_data_extent", return_value=None):
             response = view.get(request)
         assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GeoJSON API -- object permission enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tenant_structures(srid, site):
+    """Two structures in different tenants, for constraint tests."""
+    from tenancy.models import Tenant
+
+    tenant_a = Tenant.objects.create(name="Geo Tenant A", slug="geo-tenant-a")
+    tenant_b = Tenant.objects.create(name="Geo Tenant B", slug="geo-tenant-b")
+    a = Structure.objects.create(
+        name="Geo-Perm-A",
+        structure_type="manhole",
+        tenant=tenant_a,
+        geometry=Point(100, 100, srid=srid),
+        site=site,
+    )
+    b = Structure.objects.create(
+        name="Geo-Perm-B",
+        structure_type="manhole",
+        tenant=tenant_b,
+        geometry=Point(200, 200, srid=srid),
+        site=site,
+    )
+    return a, b
+
+
+@pytest.fixture
+def constrained_client(tenant_structures):
+    """API client for a user whose Structure view permission is constrained to tenant A."""
+    from django.contrib.auth import get_user_model
+    from django.contrib.contenttypes.models import ContentType
+    from users.models import ObjectPermission
+
+    user_model = get_user_model()
+    user = user_model.objects.create_user(username="geo-constrained", password="x")  # noqa: S106
+    perm = ObjectPermission.objects.create(
+        name="geo-perm-test",
+        enabled=True,
+        actions=["view"],
+        constraints={"tenant__slug": "geo-tenant-a"},
+    )
+    perm.object_types.set([ContentType.objects.get_for_model(Structure)])
+    perm.users.add(user)
+    client = APIClient()
+    # Re-fetch so no stale permission cache rides along on the user instance
+    client.force_authenticate(user=user_model.objects.get(pk=user.pk))
+    return client
+
+
+@pytest.mark.django_db
+class TestGeoObjectPermissions:
+    """Regression tests for issue #123: geo endpoints leaked objects across
+    ObjectPermission constraints (multi-tenant isolation bypass)."""
+
+    def test_structures_endpoint_honours_constraints(self, constrained_client, tenant_structures):
+        resp = constrained_client.get("/api/plugins/pathways/geo/structures/", format="json")
+        assert resp.status_code == 200
+        names = {f["properties"]["name"] for f in resp.json()["features"]}
+        assert names == {"Geo-Perm-A"}
+
+    def test_info_counts_honour_constraints(self, constrained_client, tenant_structures):
+        resp = constrained_client.get("/api/plugins/pathways/geo/info/", format="json")
+        assert resp.status_code == 200
+        # Only the tenant-A structure may be counted; the user holds no
+        # permission at all on the other layer models, so those count 0.
+        counts = resp.json()["counts"]
+        assert counts["structures"] == 1
+        assert counts["conduits"] == 0


### PR DESCRIPTION
## Summary
- The seven `geo/*` GeoJSON endpoints and the `/info` layer counts ignored NetBox object-level permissions: any user with a constrained view permission on a model received every row, leaking other tenants' plant data through the map and the API.
- Apply `restrict(user, 'view')` at the shared choke points, mirroring NetBox core's `BaseViewSet.initial()` enforcement.
- Regression tests reproduce the leak with a tenant-constrained `ObjectPermission` and fail on current `main`.

## Changes
- `netbox_pathways/api/geo.py`: `BboxFilterMixin.get_queryset()` now restricts the queryset to the requesting user's permitted objects (covers all seven layer viewsets, including the clustered structures path, which derives from `get_queryset()`); `MapInfoView` counts each layer from `model.objects.restrict(...)` instead of `model.objects.all()`.
- `tests/test_geo_api.py`: regression tests for the layer endpoint and the `/info` counts under a tenant-constrained view permission.
- `CHANGELOG.md`: Security entry under `[Unreleased]`.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (681 passed, coverage 80.6%)
- [x] New/changed behavior covered by tests
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (CHANGELOG; docs already state endpoints respect NetBox permissions, which this makes true)

## Related
Fixes: #123
