### PR TITLE
feat: split a pathway at structures into per-hop spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`split_pathway` management command.** Splits a pathway at the structures
   it passes into per-hop pathways, with PostGIS candidate detection,
-  dry-run preview, containment cascade (conduit banks and innerducts), and
-  cable segment re-routing. Refs #87.
+  dry-run preview, containment cascade (conduit banks and innerducts),
+  cable segment re-routing, and optional change logging via --user.
+  Refs #87.
 
 - **Add-child buttons that inherit the parent's attributes.** The Conduits
   panel on a conduit bank and the Innerducts panel on a conduit now carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`split_pathway` management command.** Splits a pathway at the structures
+  it passes into per-hop pathways, with PostGIS candidate detection,
+  dry-run preview, containment cascade (conduit banks and innerducts), and
+  cable segment re-routing. Refs #87.
+
 - **Add-child buttons that inherit the parent's attributes.** The Conduits
   panel on a conduit bank and the Innerducts panel on a conduit now carry
   an "Add" button that opens the create form pre-filled from the parent:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **Pathways** -- conduits, aerial spans, direct buried, innerducts, cable trays with PostGIS line geometry; a computed `geo_length` (PostGIS `ST_Length`) sits alongside the manual as-built `length` so the drawn-versus-field distinction is always visible and sortable.
 - **Conduit Banks and Junctions** -- model conduit bank configurations and mid-span Y-tees.
 - **Cable Routing** -- track which NetBox cables traverse which pathways, in sequence.
+- **Pathway Splitting** -- `manage.py split_pathway` replaces a long imported polyline with per-hop pathways between the structures it passes (dry-run preview, PostGIS candidate detection, cable segments re-routed).
 - **Pull Sheets** -- printable cable routing documents for field crews.
 - **GeoJSON API** -- standard GeoJSON endpoints for QGIS and other GIS clients.
 - **QGIS Integration** -- style files, project generator, and documentation.

--- a/docs/user-guide/pathways.md
+++ b/docs/user-guide/pathways.md
@@ -210,7 +210,10 @@ junctions (their positions along the trunk would be invalidated). Planned
 routes referencing the pathway are reported so they can be re-planned;
 waypoints cannot be repositioned and are deleted with the original.
 
-Like the plugin's other management commands, `split_pathway` operates
-outside NetBox's request pipeline: the deletion and creations do not
-produce change-log entries, webhooks, or event-rule triggers. Use the
-dry-run preview to review the operation before applying it.
+By default `split_pathway` operates outside NetBox's request pipeline:
+the deletion and creations do not produce change-log entries, webhooks,
+or event-rule triggers, and the dry-run preview is the review step. Pass
+`--user <username>` to run the apply inside the event pipeline instead --
+the change log then records the split attributed to that user (grouped
+under a single request id), and webhooks and event rules fire as they
+would for a UI edit.

--- a/docs/user-guide/pathways.md
+++ b/docs/user-guide/pathways.md
@@ -162,3 +162,50 @@ Pathway lists support filtering by:
 ## Intermediate Locations
 
 Pathways can pass through intermediate locations (sites or rooms) along their route. Use **Pathway Locations** to record these waypoints with sequence numbers for ordering. This is useful for documenting that a conduit passes through multiple manholes along its route.
+
+## Splitting an imported pathway at structures
+
+Geometry imported from KMZ files or other OSP tools often arrives as one
+long polyline that physically passes many structures (a pole line, for
+example) but is stored as a single pathway. In the pathways data model a
+span is the hop between two structures, so the mid-span structures are not
+connected to the pathway at all: nothing can branch or be routed at them,
+and per-hop attributes cannot be recorded.
+
+The `split_pathway` management command replaces such a pathway with
+consecutive per-hop pathways of the same type:
+
+```
+python manage.py split_pathway 42                     # preview candidates
+python manage.py split_pathway 42 --exclude 17 --apply
+```
+
+The default run is a dry-run preview: it detects structures within
+`--tolerance` (SRID units, default 1.0) of the pathway's line, excluding
+its endpoints, and prints them ordered by chainage together with each
+structure's offset from the line and the resulting hop layout. Nothing is
+written until you re-run with `--apply`.
+
+- `--exclude ID ...` drops false positives from the detected candidates
+  (a parallel pole line caught by the tolerance, for example).
+- `--structures ID ...` bypasses detection and splits at exactly the given
+  structures.
+
+On apply, in one transaction:
+
+- The pathway is replaced by one child per hop, with vertices preserved and
+  the cut vertices snapped onto the structure points. Shared attributes,
+  tags, and custom fields are copied; per-side attributes (faces,
+  attachment heights) stay on the first and last child; labels get an
+  `(i/total)` suffix.
+- A conduit bank's conduits and their innerducts are cascaded into per-hop
+  copies attached to the corresponding hop.
+- Cable segments routed through the pathway are replaced by per-hop
+  segments in path order, preserving sequence order and lashing.
+- The original pathway is deleted.
+
+The command refuses indoor pathways (no geometry), innerducts and
+bank-contained conduits (split the container instead), and conduits with
+junctions (their positions along the trunk would be invalidated). Planned
+routes referencing the pathway are reported so they can be re-planned;
+waypoints cannot be repositioned and are deleted with the original.

--- a/docs/user-guide/pathways.md
+++ b/docs/user-guide/pathways.md
@@ -209,3 +209,8 @@ bank-contained conduits (split the container instead), and conduits with
 junctions (their positions along the trunk would be invalidated). Planned
 routes referencing the pathway are reported so they can be re-planned;
 waypoints cannot be repositioned and are deleted with the original.
+
+Like the plugin's other management commands, `split_pathway` operates
+outside NetBox's request pipeline: the deletion and creations do not
+produce change-log entries, webhooks, or event-rule triggers. Use the
+dry-run preview to review the operation before applying it.

--- a/netbox_pathways/management/commands/split_pathway.py
+++ b/netbox_pathways/management/commands/split_pathway.py
@@ -6,6 +6,7 @@ chainage, together with the resulting hop layout and any warnings.
 Re-run with --apply to execute the split atomically.
 """
 
+from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand, CommandError
 
 from netbox_pathways.models import Pathway, Structure
@@ -68,10 +69,15 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("Dry run -- re-run with --apply to execute."))
             return
 
-        result = execute_split(plan)
+        try:
+            result = execute_split(plan)
+        except ValidationError as exc:
+            raise CommandError(f"Split failed validation: {exc}") from None
         self._print_result(result)
 
     def _resolve_structures(self, pathway, options, tolerance):
+        if options["structures"] and options["exclude"]:
+            raise CommandError("--exclude only applies to detected candidates; do not combine it with --structures.")
         if options["structures"]:
             structures = list(Structure.objects.filter(pk__in=options["structures"]))
             missing = set(options["structures"]) - {s.pk for s in structures}

--- a/netbox_pathways/management/commands/split_pathway.py
+++ b/netbox_pathways/management/commands/split_pathway.py
@@ -1,0 +1,111 @@
+"""Split a pathway at intermediate structures into per-hop pathways.
+
+The default run is a dry-run preview: it detects candidate structures
+within the tolerance of the pathway's line and prints them ordered by
+chainage, together with the resulting hop layout and any warnings.
+Re-run with --apply to execute the split atomically.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from netbox_pathways.models import Pathway, Structure
+from netbox_pathways.split import (
+    DEFAULT_TOLERANCE,
+    SplitError,
+    execute_split,
+    find_candidates,
+    plan_split,
+)
+
+
+class Command(BaseCommand):
+    help = "Split a pathway at intermediate structures into per-hop pathways."
+
+    def add_arguments(self, parser):
+        parser.add_argument("pathway_pk", type=int, help="PK of the pathway to split")
+        parser.add_argument(
+            "--tolerance",
+            type=float,
+            default=DEFAULT_TOLERANCE,
+            help="Detection tolerance in SRID units (metres on projected SRIDs); default %(default)s",
+        )
+        parser.add_argument(
+            "--structures",
+            type=int,
+            nargs="+",
+            metavar="ID",
+            help="Split at exactly these structure PKs instead of detecting candidates",
+        )
+        parser.add_argument(
+            "--exclude",
+            type=int,
+            nargs="+",
+            metavar="ID",
+            default=[],
+            help="Structure PKs to drop from the detected candidates",
+        )
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Execute the split (without this flag the command only previews)",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            pathway = Pathway.objects.get(pk=options["pathway_pk"])
+        except Pathway.DoesNotExist:
+            raise CommandError(f"Pathway {options['pathway_pk']} does not exist.") from None
+
+        tolerance = options["tolerance"]
+        try:
+            structures = self._resolve_structures(pathway, options, tolerance)
+            plan = plan_split(pathway, structures, tolerance)
+        except SplitError as exc:
+            raise CommandError(str(exc)) from None
+
+        self._print_plan(plan)
+        if not options["apply"]:
+            self.stdout.write(self.style.WARNING("Dry run -- re-run with --apply to execute."))
+            return
+
+        result = execute_split(plan)
+        self._print_result(result)
+
+    def _resolve_structures(self, pathway, options, tolerance):
+        if options["structures"]:
+            structures = list(Structure.objects.filter(pk__in=options["structures"]))
+            missing = set(options["structures"]) - {s.pk for s in structures}
+            if missing:
+                raise CommandError(f"Structure PK(s) not found: {sorted(missing)}")
+            return structures
+        candidates = find_candidates(pathway, tolerance)
+        excluded = set(options["exclude"])
+        return [c.structure for c in candidates if c.structure.pk not in excluded]
+
+    def _print_plan(self, plan):
+        pathway = plan.pathway
+        self.stdout.write(f"Pathway: {pathway} ({pathway.pathway_type}, pk {pathway.pk})")
+        self.stdout.write("Split structures (ordered along the path):")
+        self.stdout.write(f"  {'pk':>8}  {'chainage':>10}  {'offset':>8}  name")
+        for cut in plan.cuts:
+            self.stdout.write(f"  {cut.structure.pk:>8}  {cut.chainage:>10.2f}  {cut.offset:>8.2f}  {cut.structure}")
+        hops = [
+            str(pathway.start_endpoint or "?"),
+            *(str(cut.structure) for cut in plan.cuts),
+            str(pathway.end_endpoint or "?"),
+        ]
+        self.stdout.write("Resulting hops: " + " -> ".join(hops))
+        for warning in plan.warnings:
+            self.stdout.write(self.style.WARNING(f"WARNING: {warning}"))
+
+    def _print_result(self, result):
+        self.stdout.write(self.style.SUCCESS(f"Created {len(result.children)} pathways:"))
+        for child in result.children:
+            self.stdout.write(
+                f"  pk {child.pk}: {child} ({child.start_endpoint} -> {child.end_endpoint}, "
+                f"{child.geo_length or '?'} m)"
+            )
+        for original, copies in result.cascaded:
+            self.stdout.write(f"  cascaded {type(original).__name__} into {len(copies)} per-hop copies")
+        for cable, segments in result.rerouted:
+            self.stdout.write(f"  re-routed cable {cable} across {len(segments)} segments")

--- a/netbox_pathways/management/commands/split_pathway.py
+++ b/netbox_pathways/management/commands/split_pathway.py
@@ -6,8 +6,13 @@ chainage, together with the resulting hop layout and any warnings.
 Re-run with --apply to execute the split atomically.
 """
 
+import uuid
+
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand, CommandError
+from netbox.context_managers import event_tracking
+from utilities.request import NetBoxFakeRequest
 
 from netbox_pathways.models import Pathway, Structure
 from netbox_pathways.split import (
@@ -50,12 +55,23 @@ class Command(BaseCommand):
             action="store_true",
             help="Execute the split (without this flag the command only previews)",
         )
+        parser.add_argument(
+            "--user",
+            metavar="USERNAME",
+            help=(
+                "NetBox username to attribute the split to. When given, --apply runs "
+                "inside NetBox's event pipeline: change-log entries are recorded and "
+                "webhooks/event rules fire. Without it the split bypasses the pipeline."
+            ),
+        )
 
     def handle(self, *args, **options):
         try:
             pathway = Pathway.objects.get(pk=options["pathway_pk"])
         except Pathway.DoesNotExist:
             raise CommandError(f"Pathway {options['pathway_pk']} does not exist.") from None
+
+        user = self._resolve_user(options["user"])
 
         tolerance = options["tolerance"]
         try:
@@ -70,10 +86,39 @@ class Command(BaseCommand):
             return
 
         try:
-            result = execute_split(plan)
+            result = self._execute(plan, user)
         except ValidationError as exc:
             raise CommandError(f"Split failed validation: {exc}") from None
         self._print_result(result)
+
+    def _resolve_user(self, username):
+        if not username:
+            return None
+        user_model = get_user_model()
+        try:
+            return user_model.objects.get(username=username)
+        except user_model.DoesNotExist:
+            raise CommandError(f"User '{username}' does not exist.") from None
+
+    def _execute(self, plan, user):
+        """Run the split, inside NetBox's event pipeline when a user is given."""
+        if user is None:
+            return execute_split(plan)
+        request = NetBoxFakeRequest(
+            {
+                "META": {},
+                "COOKIES": {},
+                "POST": {},
+                "GET": {},
+                "FILES": {},
+                "user": user,
+                "method": "POST",
+                "path": "",
+                "id": uuid.uuid4(),
+            }
+        )
+        with event_tracking(request):
+            return execute_split(plan)
 
     def _resolve_structures(self, pathway, options, tolerance):
         if options["structures"] and options["exclude"]:

--- a/netbox_pathways/split.py
+++ b/netbox_pathways/split.py
@@ -15,6 +15,7 @@ from django.db import transaction
 
 from .models import (
     AerialSpan,
+    CableSegment,
     Conduit,
     ConduitBank,
     DirectBuried,
@@ -329,6 +330,60 @@ def _delete_originals(original):
     original.delete()
 
 
+def _reroute_segments(pairs):
+    """Replace cable segments on split pathways with per-hop segments.
+
+    `pairs` is [(original, children), ...] across the whole split so that
+    lashing between two re-routed segments (e.g. two cables in the same
+    split conduit) can be restored hop-by-hop. Returns
+    [(cable, new_segments), ...].
+    """
+    replaced = {}
+    rerouted = []
+    for original, children in pairs:
+        for segment in CableSegment.objects.filter(pathway=original).select_related("cable"):
+            # A cable that transits the same pathway twice gets renumbered by
+            # its own earlier replacement; re-read so `sequence` is current.
+            segment.refresh_from_db(fields=["sequence"])
+            old_pk = segment.pk
+            cable = segment.cable
+            sequence = segment.sequence
+            comments = segment.comments
+            peer_pks = list(segment.lashed_with.values_list("pk", flat=True))
+            segment.delete()
+            shift = len(children) - 1
+            if shift:
+                later = CableSegment.objects.filter(cable=cable, sequence__gt=sequence).order_by("-sequence")
+                for later_segment in later:
+                    later_segment.sequence += shift
+                    later_segment.save()
+            new_segments = [
+                CableSegment.objects.create(
+                    cable=cable,
+                    pathway=child,
+                    sequence=sequence + i,
+                    comments=comments,
+                )
+                for i, child in enumerate(children)
+            ]
+            replaced[old_pk] = (peer_pks, new_segments)
+            rerouted.append((cable, new_segments))
+    # Restore lashing once every replacement exists. A peer that was itself
+    # replaced is lashed hop-by-hop; a surviving peer is lashed to every
+    # replacement of the old segment.
+    for peer_pks, new_segments in replaced.values():
+        for peer_pk in peer_pks:
+            if peer_pk in replaced:
+                for hop_segment, peer_hop_segment in zip(new_segments, replaced[peer_pk][1], strict=True):
+                    hop_segment.lashed_with.add(peer_hop_segment)
+            else:
+                peer = CableSegment.objects.filter(pk=peer_pk).first()
+                if peer:
+                    for new_segment in new_segments:
+                        new_segment.lashed_with.add(peer)
+    return rerouted
+
+
 def execute_split(plan):
     """Replace the planned pathway with per-hop children, atomically."""
     original = plan.pathway
@@ -337,5 +392,6 @@ def execute_split(plan):
         children = _create_children(original, plan.cuts, pieces)
         cascaded = []
         _cascade(original, children, plan.cuts, cascaded)
+        rerouted = _reroute_segments([(original, children), *cascaded])
         _delete_originals(original)
-    return SplitResult(children=children, cascaded=cascaded, warnings=list(plan.warnings))
+    return SplitResult(children=children, cascaded=cascaded, rerouted=rerouted, warnings=list(plan.warnings))

--- a/netbox_pathways/split.py
+++ b/netbox_pathways/split.py
@@ -278,6 +278,9 @@ def _create_children(original, cuts, pieces, parents=None, parent_field=None):
         child = cls()
         for attname in shared:
             setattr(child, attname, getattr(original, attname))
+        # Subclass save() overwrites this; base-typed pathways (e.g.
+        # submarine) have no subclass to do it, so copy explicitly.
+        child.pathway_type = original.pathway_type
         child.path = pieces[i] if pieces else None
         if original.label:
             child.label = f"{original.label} ({i + 1}/{total})"

--- a/netbox_pathways/split.py
+++ b/netbox_pathways/split.py
@@ -8,11 +8,19 @@ those points, and replaces the pathway with consecutive per-hop pathways.
 """
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from django.contrib.gis.geos import LineString
 
-from .models import Structure
+from .models import (
+    AerialSpan,
+    Conduit,
+    ConduitBank,
+    DirectBuried,
+    Innerduct,
+    PlannedRoute,
+    Structure,
+)
 
 # A pathway endpoint or a neighbouring cut closer than this (in SRID units)
 # collapses into one cut instead of producing a zero-length hop.
@@ -91,3 +99,112 @@ def _cut_line(line, cuts):
         walked = seg_end_chainage
     pieces.append(current)
     return [LineString(piece, srid=line.srid) for piece in pieces]
+
+
+_TYPE_TO_MODEL = {
+    "conduit_bank": ConduitBank,
+    "conduit": Conduit,
+    "aerial": AerialSpan,
+    "direct_buried": DirectBuried,
+    "innerduct": Innerduct,
+}
+
+
+@dataclass
+class SplitPlan:
+    """A validated split: concrete pathway, ordered cuts, prospective warnings."""
+
+    pathway: object
+    cuts: list
+    warnings: list = field(default_factory=list)
+
+
+def _concrete(pathway):
+    """Resolve a base Pathway row to its MTI subclass instance."""
+    cls = _TYPE_TO_MODEL.get(pathway.pathway_type)
+    if cls is None or isinstance(pathway, cls):
+        return pathway
+    return cls.objects.get(pk=pathway.pk)
+
+
+def _contained(original):
+    """Dependent pathways that follow `original`'s route and cascade with it."""
+    contained = []
+    if isinstance(original, ConduitBank):
+        for conduit in Conduit.objects.filter(conduit_bank=original):
+            contained.append(conduit)
+            contained.extend(Innerduct.objects.filter(parent_conduit=conduit))
+    elif isinstance(original, Conduit):
+        contained.extend(Innerduct.objects.filter(parent_conduit=original))
+    return contained
+
+
+def _check_splittable(original):
+    if isinstance(original, Innerduct):
+        raise SplitError("Innerducts follow their parent conduit; split the conduit instead.")
+    if isinstance(original, Conduit) and original.conduit_bank_id:
+        raise SplitError("This conduit is contained in a bank; split the conduit bank instead.")
+    if original.path is None:
+        raise SplitError("Pathway has no geometry path; only pathways with a drawn path can be split.")
+    involved = [original, *_contained(original)]
+    for pathway in involved:
+        if not isinstance(pathway, Conduit):
+            continue
+        has_junctions = (
+            pathway.start_junction_id
+            or pathway.end_junction_id
+            or pathway.junctions_on_trunk.exists()
+            or pathway.junction_as_branch.exists()
+        )
+        if has_junctions:
+            raise SplitError(
+                f"Conduit {pathway} has junctions; splitting would invalidate their positions on the trunk."
+            )
+
+
+def _resolve_cuts(original, structures, tolerance, warnings):
+    """Project structures onto the path; validate, order, and collapse them."""
+    line = original.path
+    entries = []
+    for structure in structures:
+        offset = structure.geometry.distance(line)
+        if offset > tolerance:
+            raise SplitError(f"Structure {structure} is {offset:.2f} SRID units from the path (tolerance {tolerance}).")
+        chainage = line.project(structure.centroid)
+        if chainage <= CUT_EPSILON or chainage >= line.length - CUT_EPSILON:
+            warnings.append(f"Structure {structure} projects onto a path end; skipped.")
+            continue
+        entries.append(Candidate(structure=structure, chainage=chainage, offset=offset))
+    entries.sort(key=lambda c: c.chainage)
+    cuts = []
+    for candidate in entries:
+        if cuts and candidate.chainage - cuts[-1].chainage <= CUT_EPSILON:
+            warnings.append(
+                f"Structure {candidate.structure} coincides with {cuts[-1].structure}; collapsed into one cut."
+            )
+            continue
+        cuts.append(candidate)
+    return cuts
+
+
+def plan_split(pathway, structures, tolerance=DEFAULT_TOLERANCE):
+    """Validate a split and return the ordered cuts and prospective warnings.
+
+    Shared by the dry-run preview and the apply path so both see exactly the
+    same refusals and warnings.
+    """
+    original = _concrete(pathway)
+    _check_splittable(original)
+    warnings = []
+    cuts = _resolve_cuts(original, structures, tolerance, warnings)
+    if not cuts:
+        raise SplitError("No usable split structures resolved.")
+    for involved in [original, *_contained(original)]:
+        waypoint_count = involved.waypoints.count()
+        if waypoint_count:
+            warnings.append(f"{waypoint_count} waypoint(s) on {involved} cannot be repositioned and will be deleted.")
+        for route in PlannedRoute.objects.filter(pathway_ids__contains=[involved.pk]):
+            warnings.append(
+                f"Planned route #{route.pk} '{route.name}' references {involved}; re-plan it after the split."
+            )
+    return SplitPlan(pathway=original, cuts=cuts, warnings=warnings)

--- a/netbox_pathways/split.py
+++ b/netbox_pathways/split.py
@@ -7,7 +7,10 @@ module detects the structures the polyline passes, cuts the geometry at
 those points, and replaces the pathway with consecutive per-hop pathways.
 """
 
+import math
 from dataclasses import dataclass
+
+from django.contrib.gis.geos import LineString
 
 from .models import Structure
 
@@ -53,3 +56,34 @@ def find_candidates(pathway, tolerance=DEFAULT_TOLERANCE):
     ]
     candidates.sort(key=lambda c: c.chainage)
     return candidates
+
+
+def _cut_line(line, cuts):
+    """Cut a LineString at ordered (chainage, point) pairs into len(cuts)+1 pieces.
+
+    Original vertices are preserved: each lands in exactly one piece
+    according to its position along the line. Every cut vertex is written as
+    the given point (the structure's own point), so endpoint snapping in
+    Pathway.clean() is a no-op. A chainage coinciding with an existing
+    vertex replaces that vertex rather than duplicating it.
+    """
+    coords = [(p[0], p[1]) for p in line.coords]
+    remaining = list(cuts)
+    pieces = []
+    current = [coords[0]]
+    walked = 0.0
+    for seg_start, seg_end in zip(coords, coords[1:], strict=False):
+        seg_end_chainage = walked + math.dist(seg_start, seg_end)
+        replaces_vertex = False
+        while remaining and remaining[0][0] <= seg_end_chainage + CUT_EPSILON:
+            chainage, point = remaining.pop(0)
+            cut_xy = (point.x, point.y)
+            current.append(cut_xy)
+            pieces.append(current)
+            current = [cut_xy]
+            replaces_vertex = abs(chainage - seg_end_chainage) <= CUT_EPSILON
+        if not replaces_vertex:
+            current.append(seg_end)
+        walked = seg_end_chainage
+    pieces.append(current)
+    return [LineString(piece, srid=line.srid) for piece in pieces]

--- a/netbox_pathways/split.py
+++ b/netbox_pathways/split.py
@@ -299,6 +299,24 @@ def _create_children(original, cuts, pieces, parents=None, parent_field=None):
     return children
 
 
+def _cascade(original, children, cuts, out):
+    """Create per-hop copies of every contained pathway, recursively.
+
+    Bank conduits attach to the per-hop bank; innerducts attach to the
+    per-hop conduit. Contained copies carry no own path (the parent owns
+    the route).
+    """
+    if isinstance(original, ConduitBank):
+        for conduit in Conduit.objects.filter(conduit_bank=original):
+            copies = _create_children(conduit, cuts, None, parents=children, parent_field="conduit_bank")
+            out.append((conduit, copies))
+            _cascade(conduit, copies, cuts, out)
+    elif isinstance(original, Conduit):
+        for innerduct in Innerduct.objects.filter(parent_conduit=original):
+            copies = _create_children(innerduct, cuts, None, parents=children, parent_field="parent_conduit")
+            out.append((innerduct, copies))
+
+
 def _delete_originals(original):
     """Delete the split pathway and any contained pathways it carried.
 
@@ -317,5 +335,7 @@ def execute_split(plan):
     pieces = _cut_line(original.path, [(c.chainage, c.structure.centroid) for c in plan.cuts])
     with transaction.atomic():
         children = _create_children(original, plan.cuts, pieces)
+        cascaded = []
+        _cascade(original, children, plan.cuts, cascaded)
         _delete_originals(original)
-    return SplitResult(children=children, warnings=list(plan.warnings))
+    return SplitResult(children=children, cascaded=cascaded, warnings=list(plan.warnings))

--- a/netbox_pathways/split.py
+++ b/netbox_pathways/split.py
@@ -1,0 +1,55 @@
+"""Split a pathway at intermediate structures into per-hop children.
+
+Geometry imported from KMZ files or other OSP tools often arrives as one
+long polyline that physically passes many structures but is stored as a
+single pathway, contributing a single edge to the adjacency graph. This
+module detects the structures the polyline passes, cuts the geometry at
+those points, and replaces the pathway with consecutive per-hop pathways.
+"""
+
+from dataclasses import dataclass
+
+from .models import Structure
+
+# A pathway endpoint or a neighbouring cut closer than this (in SRID units)
+# collapses into one cut instead of producing a zero-length hop.
+CUT_EPSILON = 1e-6
+
+DEFAULT_TOLERANCE = 1.0
+
+
+class SplitError(Exception):
+    """Raised when a pathway cannot be split as requested."""
+
+
+@dataclass
+class Candidate:
+    """A structure the polyline passes, positioned along it."""
+
+    structure: Structure
+    chainage: float
+    offset: float
+
+
+def find_candidates(pathway, tolerance=DEFAULT_TOLERANCE):
+    """Structures within `tolerance` of the pathway's line, ordered by chainage.
+
+    The pathway's own endpoint structures are excluded. Chainage is the
+    distance along the line of the structure's projection (centroid for
+    polygon footprints); offset is the structure's distance from the line.
+    """
+    if pathway.path is None:
+        raise SplitError("Pathway has no geometry path; only pathways with a drawn path can be split.")
+    line = pathway.path
+    exclude_pks = [pk for pk in (pathway.start_structure_id, pathway.end_structure_id) if pk]
+    queryset = Structure.objects.filter(geometry__dwithin=(line, tolerance)).exclude(pk__in=exclude_pks)
+    candidates = [
+        Candidate(
+            structure=structure,
+            chainage=line.project(structure.centroid),
+            offset=structure.geometry.distance(line),
+        )
+        for structure in queryset
+    ]
+    candidates.sort(key=lambda c: c.chainage)
+    return candidates

--- a/netbox_pathways/split.py
+++ b/netbox_pathways/split.py
@@ -65,8 +65,12 @@ def _cut_line(line, cuts):
     according to its position along the line. Every cut vertex is written as
     the given point (the structure's own point), so endpoint snapping in
     Pathway.clean() is a no-op. A chainage coinciding with an existing
-    vertex replaces that vertex rather than duplicating it.
+    vertex replaces that vertex rather than duplicating it. Cuts must be
+    strictly interior: a chainage within CUT_EPSILON of either line end
+    raises ValueError -- callers filter those out before cutting.
     """
+    if cuts and (cuts[0][0] <= CUT_EPSILON or cuts[-1][0] >= line.length - CUT_EPSILON):
+        raise ValueError("cuts must be strictly interior to the line (callers filter endpoint chainages)")
     coords = [(p[0], p[1]) for p in line.coords]
     remaining = list(cuts)
     pieces = []

--- a/netbox_pathways/split.py
+++ b/netbox_pathways/split.py
@@ -11,6 +11,7 @@ import math
 from dataclasses import dataclass, field
 
 from django.contrib.gis.geos import LineString
+from django.db import transaction
 
 from .models import (
     AerialSpan,
@@ -208,3 +209,113 @@ def plan_split(pathway, structures, tolerance=DEFAULT_TOLERANCE):
                 f"Planned route #{route.pk} '{route.name}' references {involved}; re-plan it after the split."
             )
     return SplitPlan(pathway=original, cuts=cuts, warnings=warnings)
+
+
+# Fields never copied onto children: identity and audit columns, the
+# geometry and endpoints (set per hop), the manual as-built length (not
+# divisible across hops), the label (re-suffixed), and containment FKs
+# (set by the cascade).
+_SKIP_FIELDS = {
+    "id",
+    "created",
+    "last_updated",
+    "path",
+    "length",
+    "label",
+    "pathway_type",
+    "conduit_bank",
+    "parent_conduit",
+}
+
+
+@dataclass
+class SplitResult:
+    """What a split produced: per-hop children, cascaded copies, re-routed segments."""
+
+    children: list
+    cascaded: list = field(default_factory=list)
+    rerouted: list = field(default_factory=list)
+    warnings: list = field(default_factory=list)
+
+
+def _copyable_fields(cls):
+    """Concrete fields to copy onto children, split by sidedness.
+
+    Fields named start_*/end_* are per-side: the start value belongs to the
+    first child only and the end value to the last child only (this covers
+    the endpoint FKs, faces, and attachment heights uniformly).
+    """
+    shared, start_side, end_side = [], [], []
+    for f in cls._meta.concrete_fields:
+        if f.primary_key or f.name in _SKIP_FIELDS:
+            continue
+        if f.remote_field and getattr(f.remote_field, "parent_link", False):
+            continue
+        if f.name.startswith("start_"):
+            start_side.append(f.attname)
+        elif f.name.startswith("end_"):
+            end_side.append(f.attname)
+        else:
+            shared.append(f.attname)
+    return shared, start_side, end_side
+
+
+def _create_children(original, cuts, pieces, parents=None, parent_field=None):
+    """Create the per-hop copies of `original`, one per hop, in path order.
+
+    `pieces` is the list of cut LineStrings for the pathway that owns the
+    geometry, or None for contained children (bank conduits, innerducts)
+    whose route is owned by their parent. `parents`/`parent_field` attach
+    each contained copy to the corresponding per-hop parent.
+    """
+    cls = type(original)
+    shared, start_side, end_side = _copyable_fields(cls)
+    total = len(cuts) + 1
+    tags = list(original.tags.all())
+    children = []
+    for i in range(total):
+        child = cls()
+        for attname in shared:
+            setattr(child, attname, getattr(original, attname))
+        child.path = pieces[i] if pieces else None
+        if original.label:
+            child.label = f"{original.label} ({i + 1}/{total})"
+        if i == 0:
+            for attname in start_side:
+                setattr(child, attname, getattr(original, attname))
+        else:
+            child.start_structure = cuts[i - 1].structure
+        if i == total - 1:
+            for attname in end_side:
+                setattr(child, attname, getattr(original, attname))
+        else:
+            child.end_structure = cuts[i].structure
+        if parents is not None:
+            setattr(child, parent_field, parents[i])
+        child.full_clean()
+        child.save()
+        child.tags.set(tags)
+        children.append(child)
+    return children
+
+
+def _delete_originals(original):
+    """Delete the split pathway and any contained pathways it carried.
+
+    Conduit.conduit_bank is SET_NULL, so a bank's conduits must be deleted
+    explicitly (their innerducts cascade); a conduit's innerducts cascade
+    on their own.
+    """
+    if isinstance(original, ConduitBank):
+        Conduit.objects.filter(conduit_bank=original).delete()
+    original.delete()
+
+
+def execute_split(plan):
+    """Replace the planned pathway with per-hop children, atomically."""
+    original = plan.pathway
+    pieces = _cut_line(original.path, [(c.chainage, c.structure.centroid) for c in plan.cuts])
+    with transaction.atomic():
+        children = _create_children(original, plan.cuts, pieces)
+        _delete_originals(original)
+    return SplitResult(children=children, warnings=list(plan.warnings))

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -9,7 +9,7 @@ from django.contrib.gis.geos import LineString, Point
 
 from netbox_pathways.geo import get_srid
 from netbox_pathways.models import AerialSpan, Structure
-from netbox_pathways.split import SplitError, find_candidates
+from netbox_pathways.split import SplitError, _cut_line, find_candidates
 
 SRID = get_srid()
 
@@ -48,3 +48,50 @@ class TestFindCandidates:
         span = AerialSpan(path=None)
         with pytest.raises(SplitError, match="path"):
             find_candidates(span, tolerance=1.0)
+
+
+class TestCutLine:
+    """Pure-geometry tests; no DB needed."""
+
+    def test_vertices_land_in_the_right_children(self):
+        line = LineString((0, 0), (100, 0), (200, 0), (300, 0), (400, 0), (500, 0), srid=SRID)
+        cuts = [
+            (150.0, Point(150, 0, srid=SRID)),
+            (350.0, Point(350, 0, srid=SRID)),
+        ]
+        pieces = _cut_line(line, cuts)
+        assert [tuple(p.coords) for p in pieces] == [
+            ((0.0, 0.0), (100.0, 0.0), (150.0, 0.0)),
+            ((150.0, 0.0), (200.0, 0.0), (300.0, 0.0), (350.0, 0.0)),
+            ((350.0, 0.0), (400.0, 0.0), (500.0, 0.0)),
+        ]
+
+    def test_cut_on_existing_vertex_replaces_it(self):
+        line = LineString((0, 0), (100, 0), (200, 0), srid=SRID)
+        # Structure sits 0.3 off the drawn vertex; the vertex is replaced by
+        # the structure point, not duplicated (no zero-length segment).
+        pieces = _cut_line(line, [(100.0, Point(100, 0.3, srid=SRID))])
+        assert [tuple(p.coords) for p in pieces] == [
+            ((0.0, 0.0), (100.0, 0.3)),
+            ((100.0, 0.3), (200.0, 0.0)),
+        ]
+
+    def test_offline_cut_point_is_written_verbatim(self):
+        line = LineString((0, 0), (300, 0), srid=SRID)
+        pieces = _cut_line(line, [(150.0, Point(150, 0.4, srid=SRID))])
+        assert tuple(pieces[0].coords) == ((0.0, 0.0), (150.0, 0.4))
+        assert tuple(pieces[1].coords) == ((150.0, 0.4), (300.0, 0.0))
+
+    def test_two_cuts_in_the_same_segment(self):
+        line = LineString((0, 0), (300, 0), srid=SRID)
+        pieces = _cut_line(line, [(100.0, Point(100, 0, srid=SRID)), (200.0, Point(200, 0, srid=SRID))])
+        assert [tuple(p.coords) for p in pieces] == [
+            ((0.0, 0.0), (100.0, 0.0)),
+            ((100.0, 0.0), (200.0, 0.0)),
+            ((200.0, 0.0), (300.0, 0.0)),
+        ]
+
+    def test_srid_preserved(self):
+        line = LineString((0, 0), (300, 0), srid=SRID)
+        pieces = _cut_line(line, [(150.0, Point(150, 0, srid=SRID))])
+        assert all(p.srid == SRID for p in pieces)

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -20,7 +20,7 @@ from netbox_pathways.models import (
     PlannedRoute,
     Structure,
 )
-from netbox_pathways.split import SplitError, _cut_line, find_candidates, plan_split
+from netbox_pathways.split import SplitError, _cut_line, execute_split, find_candidates, plan_split
 
 SRID = get_srid()
 
@@ -236,3 +236,98 @@ class TestPlanSplit:
         plan = plan_split(span, [mid], tolerance=1.0)
         assert any("waypoint" in w for w in plan.warnings)
         assert any(route.name in w for w in plan.warnings)
+
+
+@pytest.mark.django_db
+class TestExecuteSplit:
+    def _split_span(self, prefix, **span_kwargs):
+        start = _structure(f"{prefix}-A", 0, 0)
+        end = _structure(f"{prefix}-B", 300, 0)
+        span = _span(start, end, LineString((0, 0), (150, 10), (300, 0), srid=SRID), **span_kwargs)
+        mid = _structure(f"{prefix}-mid", 150, 10)
+        plan = plan_split(span, [mid], tolerance=1.0)
+        return execute_split(plan), span, start, mid, end
+
+    def test_children_replace_original_with_correct_endpoints(self):
+        result, span, start, mid, end = self._split_span("EX1")
+
+        assert not Pathway.objects.filter(pk=span.pk).exists()
+        assert len(result.children) == 2
+        first, second = result.children
+        assert isinstance(first, AerialSpan) and isinstance(second, AerialSpan)
+        assert (first.start_structure, first.end_structure) == (start, mid)
+        assert (second.start_structure, second.end_structure) == (mid, end)
+        assert tuple(first.path.coords) == ((0.0, 0.0), (150.0, 10.0))
+        assert tuple(second.path.coords) == ((150.0, 10.0), (300.0, 0.0))
+
+    def test_shared_fields_tags_and_labels_copied(self):
+        start = _structure("EX2-A", 0, 0)
+        end = _structure("EX2-B", 300, 0)
+        span = _span(
+            start,
+            end,
+            LineString((0, 0), (300, 0), srid=SRID),
+            label="POLE-RUN",
+            status="planned",
+            aerial_type="messenger",
+            comments="imported from kmz",
+            length=299.5,
+        )
+        span.tags.add("import-batch-7")
+        mid = _structure("EX2-mid", 100, 0)
+        result = execute_split(plan_split(span, [mid], tolerance=1.0))
+
+        first, second = result.children
+        assert first.label == "POLE-RUN (1/2)"
+        assert second.label == "POLE-RUN (2/2)"
+        for child in result.children:
+            assert child.status == "planned"
+            assert child.aerial_type == "messenger"
+            assert child.comments == "imported from kmz"
+            assert child.length is None  # as-built length is not divisible
+            assert [t.name for t in child.tags.all()] == ["import-batch-7"]
+
+    def test_per_side_fields_go_to_first_and_last_child_only(self):
+        start = _structure("EX3-A", 0, 0)
+        end = _structure("EX3-B", 300, 0)
+        span = _span(
+            start,
+            end,
+            LineString((0, 0), (300, 0), srid=SRID),
+            start_attachment_height=6.5,
+            end_attachment_height=7.0,
+        )
+        m1 = _structure("EX3-m1", 100, 0)
+        m2 = _structure("EX3-m2", 200, 0)
+        result = execute_split(plan_split(span, [m1, m2], tolerance=1.0))
+
+        first, middle, last = result.children
+        assert first.start_attachment_height == 6.5
+        assert first.end_attachment_height is None
+        assert middle.start_attachment_height is None
+        assert middle.end_attachment_height is None
+        assert last.start_attachment_height is None
+        assert last.end_attachment_height == 7.0
+
+    def test_blank_label_stays_blank(self):
+        result, *_ = self._split_span("EX4")
+        assert all(child.label == "" for child in result.children)
+
+    def test_atomic_on_child_validation_failure(self, monkeypatch):
+        """If any child fails validation the original must survive untouched."""
+        start = _structure("EX5-A", 0, 0)
+        end = _structure("EX5-B", 300, 0)
+        span = _span(start, end, LineString((0, 0), (300, 0), srid=SRID))
+        mid = _structure("EX5-mid", 150, 0)
+        plan = plan_split(span, [mid], tolerance=1.0)
+
+        from django.core.exceptions import ValidationError
+
+        def boom(self):
+            raise ValidationError("forced failure")
+
+        monkeypatch.setattr(AerialSpan, "full_clean", boom)
+        with pytest.raises(ValidationError):
+            execute_split(plan)
+        assert Pathway.objects.filter(pk=span.pk).exists()
+        assert AerialSpan.objects.count() == 1

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -95,3 +95,13 @@ class TestCutLine:
         line = LineString((0, 0), (300, 0), srid=SRID)
         pieces = _cut_line(line, [(150.0, Point(150, 0, srid=SRID))])
         assert all(p.srid == SRID for p in pieces)
+
+    def test_cut_at_line_start_raises(self):
+        line = LineString((0, 0), (100, 0), srid=SRID)
+        with pytest.raises(ValueError, match="interior"):
+            _cut_line(line, [(0.0, Point(0, 0, srid=SRID))])
+
+    def test_cut_at_line_end_raises(self):
+        line = LineString((0, 0), (100, 0), srid=SRID)
+        with pytest.raises(ValueError, match="interior"):
+            _cut_line(line, [(100.0, Point(100, 0, srid=SRID))])

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -5,11 +5,22 @@ per-hop pathways between the structures it passes.
 """
 
 import pytest
+from dcim.models import Site
 from django.contrib.gis.geos import LineString, Point
 
 from netbox_pathways.geo import get_srid
-from netbox_pathways.models import AerialSpan, Structure
-from netbox_pathways.split import SplitError, _cut_line, find_candidates
+from netbox_pathways.models import (
+    AerialSpan,
+    Conduit,
+    ConduitBank,
+    ConduitJunction,
+    Innerduct,
+    Pathway,
+    PathwayLocation,
+    PlannedRoute,
+    Structure,
+)
+from netbox_pathways.split import SplitError, _cut_line, find_candidates, plan_split
 
 SRID = get_srid()
 
@@ -105,3 +116,123 @@ class TestCutLine:
         line = LineString((0, 0), (100, 0), srid=SRID)
         with pytest.raises(ValueError, match="interior"):
             _cut_line(line, [(100.0, Point(100, 0, srid=SRID))])
+
+
+@pytest.mark.django_db
+class TestPlanSplit:
+    def _line_span(self, prefix, length=300):
+        start = _structure(f"{prefix}-A", 0, 0)
+        end = _structure(f"{prefix}-B", length, 0)
+        span = _span(start, end, LineString((0, 0), (length, 0), srid=SRID))
+        return span, start, end
+
+    def test_orders_cuts_and_resolves_concrete_subclass(self):
+        span, _, _ = self._line_span("PS1")
+        s2 = _structure("PS1-m2", 200, 0)
+        s1 = _structure("PS1-m1", 100, 0)
+        base = Pathway.objects.get(pk=span.pk)  # command fetches the base row
+
+        plan = plan_split(base, [s2, s1], tolerance=1.0)
+
+        assert isinstance(plan.pathway, AerialSpan)
+        assert [c.structure.pk for c in plan.cuts] == [s1.pk, s2.pk]
+        assert plan.warnings == []
+
+    def test_structure_beyond_tolerance_refused(self):
+        span, _, _ = self._line_span("PS2")
+        off = _structure("PS2-off", 150, 30)
+        with pytest.raises(SplitError, match="tolerance"):
+            plan_split(span, [off], tolerance=1.0)
+
+    def test_structure_at_line_end_skipped_with_warning(self):
+        span, _, _ = self._line_span("PS3")
+        at_end = _structure("PS3-end", 300, 0.5)
+        mid = _structure("PS3-mid", 150, 0)
+        plan = plan_split(span, [at_end, mid], tolerance=1.0)
+        assert [c.structure.pk for c in plan.cuts] == [mid.pk]
+        assert any("end" in w for w in plan.warnings)
+
+    def test_coincident_structures_collapse_with_warning(self):
+        span, _, _ = self._line_span("PS4")
+        s1 = _structure("PS4-s1", 150, 0.2)
+        s2 = _structure("PS4-s2", 150, -0.2)  # same chainage
+        plan = plan_split(span, [s1, s2], tolerance=1.0)
+        assert len(plan.cuts) == 1
+        assert any("collaps" in w for w in plan.warnings)
+
+    def test_no_usable_structures_refused(self):
+        span, _, _ = self._line_span("PS5")
+        with pytest.raises(SplitError, match="[Nn]o usable"):
+            plan_split(span, [], tolerance=1.0)
+
+    def test_indoor_pathway_refused(self):
+        pw = Pathway(path=None)
+        with pytest.raises(SplitError, match="path"):
+            plan_split(pw, [], tolerance=1.0)
+
+    def test_innerduct_refused(self):
+        s1 = _structure("PS6-A", 0, 0)
+        s2 = _structure("PS6-B", 100, 0)
+        conduit = Conduit.objects.create(
+            path=LineString((0, 0), (100, 0), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        duct = Innerduct.objects.create(parent_conduit=conduit, size="32mm")
+        with pytest.raises(SplitError, match="[Ii]nnerduct"):
+            plan_split(duct, [], tolerance=1.0)
+
+    def test_bank_contained_conduit_refused(self):
+        s1 = _structure("PS7-A", 0, 0)
+        s2 = _structure("PS7-B", 100, 0)
+        bank = ConduitBank.objects.create(
+            path=LineString((0, 0), (100, 0), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        conduit = Conduit.objects.create(conduit_bank=bank)
+        with pytest.raises(SplitError, match="bank"):
+            plan_split(conduit, [], tolerance=1.0)
+
+    def test_conduit_with_junction_refused(self):
+        s1 = _structure("PS8-A", 0, 0)
+        s2 = _structure("PS8-B", 300, 0)
+        trunk = Conduit.objects.create(
+            path=LineString((0, 0), (300, 0), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        s3 = _structure("PS8-C", 150, 100)
+        branch = Conduit.objects.create(
+            path=LineString((150, 0), (150, 100), srid=SRID),
+            end_structure=s3,
+        )
+        junction = ConduitJunction(
+            trunk_conduit=trunk,
+            branch_conduit=branch,
+            towards_structure=s2,
+            position_on_trunk=0.5,
+        )
+        junction.save()
+        branch.start_junction = junction
+        branch.save()
+        mid = _structure("PS8-mid", 100, 0)
+        with pytest.raises(SplitError, match="junction"):
+            plan_split(trunk, [mid], tolerance=1.0)
+        with pytest.raises(SplitError, match="junction"):
+            plan_split(branch, [], tolerance=1.0)
+
+    def test_waypoints_and_planned_routes_produce_warnings(self):
+        span, _, _ = self._line_span("PS9")
+        mid = _structure("PS9-mid", 150, 0)
+        site = Site.objects.create(name="PS9-site", slug="ps9-site")
+        PathwayLocation.objects.create(pathway=span, site=site, sequence=1)
+        route = PlannedRoute.objects.create(
+            name="PS9-route",
+            start_structure=span.start_structure,
+            end_structure=span.end_structure,
+            pathway_ids=[span.pk],
+        )
+        plan = plan_split(span, [mid], tolerance=1.0)
+        assert any("waypoint" in w for w in plan.warnings)
+        assert any(route.name in w for w in plan.warnings)

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -7,9 +7,12 @@ per-hop pathways between the structures it passes.
 from io import StringIO
 
 import pytest
+from core.models import ObjectChange
 from dcim.models import Cable, Site
+from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import LineString, Point
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from netbox_pathways.geo import get_srid
 from netbox_pathways.models import (
@@ -516,3 +519,32 @@ class TestCommandGating:
         call_command("split_pathway", span.pk, "--apply", stdout=out)
         assert not Pathway.objects.filter(pk=span.pk).exists()
         assert AerialSpan.objects.count() == 2
+
+    def test_user_option_writes_changelog_entries(self):
+        """--user runs the apply inside event_tracking, so the deletion and
+        creations land in the change log attributed to that user, grouped
+        under one request id."""
+        start = _structure("CMD2-A", 0, 0)
+        end = _structure("CMD2-B", 300, 0)
+        span = _span(start, end, LineString((0, 0), (300, 0), srid=SRID))
+        _structure("CMD2-mid", 150, 0)
+        user = get_user_model().objects.create_user(username="splitter")
+
+        call_command("split_pathway", span.pk, "--apply", "--user", "splitter", stdout=StringIO())
+
+        changes = ObjectChange.objects.filter(user=user)
+        assert changes.filter(action="create").count() == 2
+        # Deleting an MTI subclass instance cascades to its base Pathway row,
+        # and NetBox logs each content type separately -- assert on the
+        # subclass row and tolerate the base-row companion entry.
+        deletes = changes.filter(action="delete")
+        assert deletes.filter(changed_object_type__model="aerialspan").count() == 1
+        assert len(set(changes.values_list("request_id", flat=True))) == 1
+
+    def test_user_option_rejects_unknown_username(self):
+        start = _structure("CMD3-A", 0, 0)
+        end = _structure("CMD3-B", 300, 0)
+        span = _span(start, end, LineString((0, 0), (300, 0), srid=SRID))
+
+        with pytest.raises(CommandError, match="does not exist"):
+            call_command("split_pathway", span.pk, "--user", "ghost")

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -331,3 +331,67 @@ class TestExecuteSplit:
             execute_split(plan)
         assert Pathway.objects.filter(pk=span.pk).exists()
         assert AerialSpan.objects.count() == 1
+
+
+@pytest.mark.django_db
+class TestCascade:
+    def test_bank_split_cascades_to_conduits_and_innerducts(self):
+        s1 = _structure("CA1-A", 0, 0)
+        s2 = _structure("CA1-B", 300, 0)
+        bank = ConduitBank.objects.create(
+            path=LineString((0, 0), (300, 0), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        conduit_a = Conduit.objects.create(conduit_bank=bank, bank_position="A1", material="hdpe")
+        conduit_b = Conduit.objects.create(conduit_bank=bank, bank_position="B1")
+        duct = Innerduct.objects.create(parent_conduit=conduit_a, size="32mm", position="1")
+        mid = _structure("CA1-mid", 150, 0)
+
+        result = execute_split(plan_split(bank, [mid], tolerance=1.0))
+
+        # Bank children own the geometry.
+        bank_children = result.children
+        assert len(bank_children) == 2
+        assert all(isinstance(c, ConduitBank) for c in bank_children)
+
+        # Every contained conduit got one copy per hop, attached to the
+        # per-hop bank, keeping its bank_position and attributes.
+        new_conduits = Conduit.objects.filter(conduit_bank__in=bank_children).order_by("pk")
+        assert new_conduits.count() == 4
+        a_copies = [c for c in new_conduits if c.bank_position == "A1"]
+        assert len(a_copies) == 2
+        assert {c.conduit_bank_id for c in a_copies} == {b.pk for b in bank_children}
+        assert all(c.material == "hdpe" for c in a_copies)
+        assert all(c.path is None for c in new_conduits)
+
+        # Innerducts cascade one level further, onto the per-hop conduits.
+        new_ducts = Innerduct.objects.filter(parent_conduit__in=a_copies)
+        assert new_ducts.count() == 2
+        assert all(d.size == "32mm" and d.position == "1" for d in new_ducts)
+
+        # Originals are gone.
+        for pk in (bank.pk, conduit_a.pk, conduit_b.pk, duct.pk):
+            assert not Pathway.objects.filter(pk=pk).exists()
+
+        # The result reports the cascade.
+        cascaded_originals = {orig.pk for orig, _ in result.cascaded}
+        assert cascaded_originals == {conduit_a.pk, conduit_b.pk, duct.pk}
+
+    def test_conduit_split_cascades_to_innerducts(self):
+        s1 = _structure("CA2-A", 0, 0)
+        s2 = _structure("CA2-B", 300, 0)
+        conduit = Conduit.objects.create(
+            path=LineString((0, 0), (300, 0), srid=SRID),
+            start_structure=s1,
+            end_structure=s2,
+        )
+        duct = Innerduct.objects.create(parent_conduit=conduit, size="32mm")
+        mid = _structure("CA2-mid", 150, 0)
+
+        result = execute_split(plan_split(conduit, [mid], tolerance=1.0))
+
+        assert len(result.children) == 2
+        new_ducts = Innerduct.objects.filter(parent_conduit__in=result.children)
+        assert new_ducts.count() == 2
+        assert not Pathway.objects.filter(pk=duct.pk).exists()

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -5,12 +5,13 @@ per-hop pathways between the structures it passes.
 """
 
 import pytest
-from dcim.models import Site
+from dcim.models import Cable, Site
 from django.contrib.gis.geos import LineString, Point
 
 from netbox_pathways.geo import get_srid
 from netbox_pathways.models import (
     AerialSpan,
+    CableSegment,
     Conduit,
     ConduitBank,
     ConduitJunction,
@@ -395,3 +396,77 @@ class TestCascade:
         new_ducts = Innerduct.objects.filter(parent_conduit__in=result.children)
         assert new_ducts.count() == 2
         assert not Pathway.objects.filter(pk=duct.pk).exists()
+
+
+@pytest.mark.django_db
+class TestSegmentRerouting:
+    def _span_with_cable(self, prefix):
+        start = _structure(f"{prefix}-A", 0, 0)
+        end = _structure(f"{prefix}-B", 300, 0)
+        span = _span(start, end, LineString((0, 0), (300, 0), srid=SRID))
+        other = _span(
+            _structure(f"{prefix}-C", 300, 0.5),
+            _structure(f"{prefix}-D", 600, 0),
+            LineString((300, 0.5), (600, 0), srid=SRID),
+        )
+        return span, other
+
+    def test_segment_replaced_per_hop_and_later_sequences_renumbered(self, _disable_routability_signal):
+        span, other = self._span_with_cable("SR1")
+        cable = Cable.objects.create(label="SR1-cable")
+        seg_on_span = CableSegment.objects.create(cable=cable, pathway=span, sequence=1)
+        seg_after = CableSegment.objects.create(cable=cable, pathway=other, sequence=2)
+        mid = _structure("SR1-mid", 150, 0)
+
+        result = execute_split(plan_split(span, [mid], tolerance=1.0))
+
+        segments = list(CableSegment.objects.filter(cable=cable).order_by("sequence"))
+        assert len(segments) == 3
+        assert [s.pathway_id for s in segments[:2]] == [c.pk for c in result.children]
+        assert segments[2].pk == seg_after.pk
+        assert [s.sequence for s in segments] == [1, 2, 3]
+        assert not CableSegment.objects.filter(pk=seg_on_span.pk).exists()
+        assert result.rerouted and result.rerouted[0][0] == cable
+
+    def test_lashed_peer_on_unaffected_pathway_is_lashed_to_every_replacement(self, _disable_routability_signal):
+        span, other = self._span_with_cable("SR2")
+        cable = Cable.objects.create(label="SR2-cable")
+        peer_cable = Cable.objects.create(label="SR2-peer")
+        seg = CableSegment.objects.create(cable=cable, pathway=span, sequence=1)
+        peer = CableSegment.objects.create(cable=peer_cable, pathway=other, sequence=1)
+        seg.lashed_with.add(peer)
+        mid = _structure("SR2-mid", 150, 0)
+
+        execute_split(plan_split(span, [mid], tolerance=1.0))
+
+        new_segments = CableSegment.objects.filter(cable=cable)
+        assert new_segments.count() == 2
+        for new_seg in new_segments:
+            assert list(new_seg.lashed_with.all()) == [peer]
+
+    def test_two_rerouted_cables_lashed_together_stay_lashed_per_hop(self, _disable_routability_signal):
+        span, _ = self._span_with_cable("SR3")
+        cable_a = Cable.objects.create(label="SR3-a")
+        cable_b = Cable.objects.create(label="SR3-b")
+        seg_a = CableSegment.objects.create(cable=cable_a, pathway=span, sequence=1)
+        seg_b = CableSegment.objects.create(cable=cable_b, pathway=span, sequence=1)
+        seg_a.lashed_with.add(seg_b)
+        mid = _structure("SR3-mid", 150, 0)
+
+        result = execute_split(plan_split(span, [mid], tolerance=1.0))
+
+        for child in result.children:
+            hop_segments = list(CableSegment.objects.filter(pathway=child))
+            assert len(hop_segments) == 2
+            first, second = hop_segments
+            assert list(first.lashed_with.all()) == [second]
+
+    def test_comments_copied_to_replacements(self, _disable_routability_signal):
+        span, _ = self._span_with_cable("SR4")
+        cable = Cable.objects.create(label="SR4-cable")
+        CableSegment.objects.create(cable=cable, pathway=span, sequence=1, comments="pull note")
+        mid = _structure("SR4-mid", 150, 0)
+
+        execute_split(plan_split(span, [mid], tolerance=1.0))
+
+        assert all(s.comments == "pull note" for s in CableSegment.objects.filter(cable=cable))

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -4,9 +4,12 @@ Regression suite for issue #87: split one long imported polyline into
 per-hop pathways between the structures it passes.
 """
 
+from io import StringIO
+
 import pytest
 from dcim.models import Cable, Site
 from django.contrib.gis.geos import LineString, Point
+from django.core.management import call_command
 
 from netbox_pathways.geo import get_srid
 from netbox_pathways.models import (
@@ -474,3 +477,23 @@ class TestSegmentRerouting:
         child_pks = {c.pk for c in result.children}
         assert all(s.pathway_id in child_pks for s in segments)
         assert all(s.comments == "pull note" for s in segments)
+
+
+@pytest.mark.django_db
+class TestCommandGating:
+    def test_dry_run_previews_and_apply_executes(self):
+        start = _structure("CMD-A", 0, 0)
+        end = _structure("CMD-B", 300, 0)
+        span = _span(start, end, LineString((0, 0), (300, 0), srid=SRID))
+        mid = _structure("CMD-mid", 150, 0.3)
+
+        out = StringIO()
+        call_command("split_pathway", span.pk, stdout=out)
+        assert str(mid.pk) in out.getvalue()
+        assert "Dry run" in out.getvalue()
+        assert Pathway.objects.filter(pk=span.pk).exists()  # nothing written
+
+        out = StringIO()
+        call_command("split_pathway", span.pk, "--apply", stdout=out)
+        assert not Pathway.objects.filter(pk=span.pk).exists()
+        assert AerialSpan.objects.count() == 2

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -467,6 +467,10 @@ class TestSegmentRerouting:
         CableSegment.objects.create(cable=cable, pathway=span, sequence=1, comments="pull note")
         mid = _structure("SR4-mid", 150, 0)
 
-        execute_split(plan_split(span, [mid], tolerance=1.0))
+        result = execute_split(plan_split(span, [mid], tolerance=1.0))
 
-        assert all(s.comments == "pull note" for s in CableSegment.objects.filter(cable=cable))
+        segments = CableSegment.objects.filter(cable=cable)
+        assert segments.count() == 2
+        child_pks = {c.pk for c in result.children}
+        assert all(s.pathway_id in child_pks for s in segments)
+        assert all(s.comments == "pull note" for s in segments)

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -336,6 +336,25 @@ class TestExecuteSplit:
         assert Pathway.objects.filter(pk=span.pk).exists()
         assert AerialSpan.objects.count() == 1
 
+    def test_base_typed_pathway_children_keep_pathway_type(self):
+        """Regression test: children of a base-typed pathway (no MTI subclass,
+        e.g. submarine) must inherit pathway_type; Pathway.save() only
+        auto-fills it for subclasses."""
+        start = _structure("EX6-A", 0, 0)
+        end = _structure("EX6-B", 300, 0)
+        span = Pathway(
+            path=LineString((0, 0), (300, 0), srid=SRID),
+            start_structure=start,
+            end_structure=end,
+        )
+        span.pathway_type = "submarine"
+        span.save()
+        mid = _structure("EX6-mid", 150, 0)
+
+        result = execute_split(plan_split(span, [mid], tolerance=1.0))
+
+        assert [c.pathway_type for c in result.children] == ["submarine", "submarine"]
+
 
 @pytest.mark.django_db
 class TestCascade:

--- a/tests/test_split_pathway.py
+++ b/tests/test_split_pathway.py
@@ -1,0 +1,50 @@
+"""Tests for the pathway split service module.
+
+Regression suite for issue #87: split one long imported polyline into
+per-hop pathways between the structures it passes.
+"""
+
+import pytest
+from django.contrib.gis.geos import LineString, Point
+
+from netbox_pathways.geo import get_srid
+from netbox_pathways.models import AerialSpan, Structure
+from netbox_pathways.split import SplitError, find_candidates
+
+SRID = get_srid()
+
+
+def _structure(name, x, y):
+    return Structure.objects.create(name=name, geometry=Point(x, y, srid=SRID))
+
+
+def _span(start, end, path, **kwargs):
+    return AerialSpan.objects.create(
+        path=path,
+        start_structure=start,
+        end_structure=end,
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db
+class TestFindCandidates:
+    def test_orders_by_chainage_excludes_endpoints_and_out_of_tolerance(self):
+        start = _structure("FC-A", 0, 0)
+        end = _structure("FC-B", 300, 0)
+        near_far_along = _structure("FC-mid2", 200, 0.5)
+        near_early = _structure("FC-mid1", 100, -0.4)
+        _structure("FC-off", 150, 50)  # 50 units off the line: not a candidate
+        span = _span(start, end, LineString((0, 0), (300, 0), srid=SRID))
+
+        candidates = find_candidates(span, tolerance=1.0)
+
+        assert [c.structure.pk for c in candidates] == [near_early.pk, near_far_along.pk]
+        assert candidates[0].chainage == pytest.approx(100.0)
+        assert candidates[0].offset == pytest.approx(0.4)
+        assert candidates[1].chainage == pytest.approx(200.0)
+
+    def test_pathway_without_path_raises(self):
+        span = AerialSpan(path=None)
+        with pytest.raises(SplitError, match="path"):
+            find_candidates(span, tolerance=1.0)


### PR DESCRIPTION
## Summary
- Adds a `split_pathway` management command that replaces one long imported pathway polyline with consecutive per-hop pathways between the structures it passes (the KMZ pole-line import case)
- Candidate structures are detected server-side within a tolerance of the line (PostGIS), previewed ordered by chainage with offsets, and applied atomically with `--apply`
- The split cascades through containment (conduit bank -> conduits -> innerducts), re-routes cable segments onto the per-hop children preserving sequence order and lashing, copies shared attributes/tags, distributes per-side attributes to the first/last child, and deletes the original
- Optional `--user <username>` runs the apply inside NetBox's event pipeline so the change log records the split attributed to that user (webhooks and event rules fire as for a UI edit); without it the command bypasses the pipeline like the plugin's other management commands

## Changes
- netbox_pathways/split.py: split service module -- candidate detection, refusal validation, cut resolution, vertex-preserving geometry cutting, per-hop child creation, containment cascade, cable-segment re-routing
- netbox_pathways/management/commands/split_pathway.py: thin command -- dry-run preview by default, `--apply`, `--tolerance`, `--structures`, `--exclude`, `--user`
- tests/test_split_pathway.py: 34 unit tests of the service module plus one command-gating test
- README.md, docs/user-guide/pathways.md, CHANGELOG.md: feature entry, usage guide, changelog

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (690 passed, coverage 81.33%)
- [x] New/changed behavior covered by tests
- [x] Migration applied cleanly (no schema change -- the feature adds no model fields)
- [x] Docs updated (README, CHANGELOG, zensical pages)

## Related
Fixes #87
