### PR TITLE
chore: add NetBox 4.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
           - "4.5.10"
           # renovate: datasource=github-releases depName=netbox-community/netbox
           - "4.6.10"
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.7.0"
     services:
       postgres:
         image: postgis/postgis:17-3.4
@@ -189,7 +191,7 @@ jobs:
           pytest tests/ -v --tb=short --cov=netbox_pathways --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.5.')
+        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.7.')
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   widget's nearby-structures layer anchors polygon-footprint structures at
   their centroid instead of skipping them. Refs #90.
 
+- **NetBox 4.7 support.** The test matrix now covers NetBox 4.7.0
+  (Django 6.1) alongside 4.5.10 and 4.6.10, and coverage is reported from
+  the 4.7 lane. No runtime change was needed: the only fix was in the
+  migration tests, which seeded a `dcim.Location` through a frozen
+  historical model still declaring the MPTT tree columns that 4.7 replaces
+  with ltree paths. Refs #134.
+
 ### Changed
 
 - The Conduits table on a conduit bank's detail page now shows the Bank

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@
 
 ## Compatibility
 
-| Plugin version  | NetBox version       | Python    | PostgreSQL           |
-|-----------------|----------------------|-----------|----------------------|
-| 0.1.x -- 0.2.1  | 4.5.3 -- 4.5.x       | 3.12-3.14 | 16+ with PostGIS 3.4+|
-| 0.2.2+          | 4.5.3+ (incl. 4.6.x) | 3.12-3.14 | 16+ with PostGIS 3.4+|
+| Plugin version  | NetBox version                | Python    | PostgreSQL           |
+|-----------------|-------------------------------|-----------|----------------------|
+| 0.1.x -- 0.2.1  | 4.5.3 -- 4.5.x                | 3.12-3.14 | 16+ with PostGIS 3.4+|
+| 0.2.2+          | 4.5.3+ (incl. 4.6.x, 4.7.x)   | 3.12-3.14 | 16+ with PostGIS 3.4+|
 
 > NetBox 4.6 ships Django 6.0. Plugin versions 0.2.1 and earlier do not render
 > the geometry map widget on NetBox 4.6 (issue #52); upgrade to 0.2.2 or later

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,10 +82,10 @@ The boundary is NetBox's native `dcim.Cable` model: Pathways tracks physical rou
 
 | Component    | Version                         |
 |--------------|---------------------------------|
-| NetBox       | 4.5.3+ (incl. 4.6.x)            |
+| NetBox       | 4.5.3+ (incl. 4.6.x, 4.7.x)     |
 | Python       | 3.12+                          |
 | PostgreSQL   | 16+ with PostGIS 3.4+          |
-| Django       | 5.2 or 6.0 (ships with NetBox) |
+| Django       | 5.2, 6.0, or 6.1 (ships with NetBox) |
 | GDAL/GEOS   | System libraries for PostGIS   |
 
 ---

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,12 @@
       "matchPackageNames": ["netbox-community/netbox"],
       "matchCurrentValue": "/^4\\.6\\./",
       "allowedVersions": "/^4\\.6\\./"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.7\\./",
+      "allowedVersions": "/^4\\.7\\./"
     }
   ],
   "customManagers": [

--- a/tests/test_structure_location.py
+++ b/tests/test_structure_location.py
@@ -257,12 +257,15 @@ def test_identity_migration_fails_loudly_on_shared_locations(migrate_to):
     executor = migrate_to(pre)
     state = executor.loader.project_state([("netbox_pathways", pre)]).apps
     OldStructure = state.get_model("netbox_pathways", "Structure")
-    OldSite = state.get_model("dcim", "Site")
-    OldLocation = state.get_model("dcim", "Location")
 
-    site = OldSite.objects.create(name="Dup-Site", slug="dup-site")
-    # Historical models bypass the MPTT manager, so tree columns are set by hand.
-    loc = OldLocation.objects.create(name="Dup-Loc", slug="dup-loc", site=site, lft=1, rght=2, tree_id=1, level=0)
+    # Only netbox_pathways is rewound here: dcim's tables stay at head while its
+    # historical model state is frozen at whatever this migration depends on. That
+    # frozen dcim.Location still declares the MPTT tree columns (lft/rght/tree_id/
+    # level) that NetBox 4.7 replaced with ltree paths, so inserting through it
+    # writes columns the table no longer has. The concrete models always match the
+    # live schema, on every supported NetBox release.
+    site = Site.objects.create(name="Dup-Site", slug="dup-site")
+    loc = Location.objects.create(name="Dup-Loc", slug="dup-loc", site=site)
     OldStructure.objects.create(name="dup-1", geometry=Point(0, 0, srid=SRID), location_id=loc.pk)
     OldStructure.objects.create(name="dup-2", geometry=Point(1, 1, srid=SRID), location_id=loc.pk)
 


### PR DESCRIPTION
## Summary
- Fixes the one 4.7 test casualty: `test_identity_migration_fails_loudly_on_shared_locations` created its fixture through the historical `dcim.Location` model, whose frozen state still declares the MPTT tree columns that NetBox 4.7's ltree migrations dropped -- the INSERT failed with UndefinedColumn on a 4.7 database. The fixture now uses the concrete `dcim` models, which always match the live schema (works on 4.5/4.6 MPTT and 4.7 ltree alike). Note: the fix direction suggested in the issue (gating the tree kwargs on the historical model's fields) does not work -- Django emits the historical model's concrete fields into the INSERT column list regardless of kwargs.
- Adds NetBox 4.7.0 to the CI matrix (keeping 4.5.10 and 4.6.10), moves the coverage upload to the 4.7 lane, and adds the Renovate per-minor lane.
- Declares NetBox 4.7 compatibility in README.md, docs/index.md, and the CHANGELOG.

## Changes
- tests/test_structure_location.py: shared-location fixture built with live dcim models
- .github/workflows/ci.yml: renovate-annotated 4.7.0 matrix entry; codecov condition anchored to startsWith '4.7.'
- renovate.json: allowedVersions lane for /^4\.7\./
- README.md, docs/index.md, CHANGELOG.md: 4.7 compatibility declared

## Testing
- [x] Red on 4.7.0: `psycopg.errors.UndefinedColumn: column "lft" of relation "dcim_location" does not exist`
- [x] Green after fix: single test passes; full test_structure_location.py module passes (16 passed)
- [x] `ruff check` and `ruff format` clean on the touched file
- [x] `manage.py check` and `makemigrations --check --dry-run` clean on 4.7.0
- [ ] Full suite on 4.7 -- left to this PR's CI run (new 4.7.0 lane)
- [ ] Manual follow-up: smoke-render pullsheet_list.html on 4.7 (its core includes still exist in 4.7; render unverified)

## Related
Closes #134
